### PR TITLE
Bump version to 0m04 (in development) + placeholder for it in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,11 @@ Project website:
 
 Release notes:
 
+	0m/04, Lib 0.46 (Manual revision 31):
+
+		Compiler: Enables the color and background-color CSS properties on 
+		Z-machine.
+
 	0m/03, Lib 0.46 (Manual revision 31):
 
 		Library: Changed how darkness is handled: Unlit objects are now

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC		= gcc
-CFLAGS		+= -O3 -Wall -DVERSION=\"0m/03\"
+CFLAGS		+= -O3 -Wall -DVERSION=\"'0m/04 (in development)'\"
 WININCLUDE	= winglk
 WINLIB		= ../prebuilt/win32
 


### PR DESCRIPTION
As it say in the title.

VERSION is set in the Makefile as a compiler constant. The documentation also needs to be updated eventually.