### PR TITLE
Allow style stacking on Z-machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *.o
+dgdebug
+dialogc
+*.dg
+*.z5
+*.z8
+*.zblorb
+*.aastory

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC		= gcc
-CFLAGS		+= -O3 -Wall -DVERSION=\"0m/03\"
+CFLAGS		+= -O3 -Wall -DVERSION=\"1a/02\"
 WININCLUDE	= winglk
 WINLIB		= ../prebuilt/win32
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -343,7 +343,7 @@ struct boxclass {
 	uint16_t		margintop, marginbottom;
 	uint16_t		flags;
 	uint16_t		style;	// Which of the STYLE_* flags to turn on
-	uint16_y		unstyle; // Which of the STYLE_* flags to turn off (as opposed to leaving in their current state)
+	uint16_t		unstyle; // Which of the STYLE_* flags to turn off (as opposed to leaving in their current state)
 	int16_t			color;	// For color on the Z-machine
 	int16_t			bgcolor;
 	struct word		*class;

--- a/src/ast.h
+++ b/src/ast.h
@@ -342,7 +342,8 @@ struct boxclass {
 	uint16_t		width, height;
 	uint16_t		margintop, marginbottom;
 	uint16_t		flags;
-	uint16_t		style;	// STYLE_*
+	uint16_t		style;	// Which of the STYLE_* flags to turn on
+	uint16_y		unstyle; // Which of the STYLE_* flags to turn off (as opposed to leaving in their current state)
 	int16_t			color;	// For color on the Z-machine
 	int16_t			bgcolor;
 	struct word		*class;

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -1828,12 +1828,18 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 					zi->oper[1] = LARGE((uint16_t)(prg->boxclasses[ci->oper[0].value].color));
 					zi->oper[2] = LARGE((uint16_t)(prg->boxclasses[ci->oper[0].value].bgcolor));
 					
+					// Note that this is a change to the behavior - traditionally status areas ignored styles
+					// But to replicate the traditional behavior, we're going to apply reverse-video style unless it's specifically been turned off (by setting it in the unstyle value)
+					zi = append_instr(r, Z_CALLVN);
+					zi->oper[0] = ROUTINE(R_INIT_BOX_STYLE);
+					zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style | (prg->boxclasses[ci->oper[0].value].unstyle | STYLE_REVERSE ? 0 : STYLE_REVERSE)); // OR STYLE_REVERSE into this value unless STYLE_REVERSE is found in the unstyle value
+					zi->oper[2] = LARGE(~(prg->boxclasses[ci->oper[0].value].unstyle)); // We pass this as a sixteen-bit number instead of an eight-bit number so that it doesn't clobber the top bits of REG_STYLE, which might be used to store something else at some point
+					
 					zi = append_instr(r, Z_CALLVN);
 					zi->oper[0] = ROUTINE(R_BEGIN_STATUS);
 					zi->oper[1] = SMALL_OR_LARGE(
 						prg->boxclasses[ci->oper[0].value].height |
 						((prg->boxclasses[ci->oper[0].value].flags & BOXF_RELHEIGHT)? 0x8000 : 0));
-					zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].style);
 				} else {
 					zi = append_instr(r, Z_CALL1N);
 					zi->oper[0] = ROUTINE(R_BEGIN_NOSTATUS);
@@ -1847,10 +1853,14 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 				zi->oper[1] = LARGE((uint16_t)(prg->boxclasses[ci->oper[0].value].color));
 				zi->oper[2] = LARGE((uint16_t)(prg->boxclasses[ci->oper[0].value].bgcolor));
 				
+				zi = append_instr(r, Z_CALLVN);
+				zi->oper[0] = ROUTINE(R_INIT_BOX_STYLE);
+				zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style);
+				zi->oper[2] = LARGE(~(prg->boxclasses[ci->oper[0].value].unstyle)); // We pass this as a sixteen-bit number instead of an eight-bit number so that it doesn't clobber the top bits of REG_STYLE, which might be used to store something else at some point
+				
 				if(ci->subop == BOX_SPAN) {
-					zi = append_instr(r, Z_CALL2N);
+					zi = append_instr(r, Z_CALL1N);
 					zi->oper[0] = ROUTINE(R_BEGIN_SPAN);
-					zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style);
 				} else {
 					zi = append_instr(r, Z_CALLVN);
 					if(prg->boxclasses[ci->oper[0].value].flags & BOXF_FLOATLEFT) {
@@ -1858,19 +1868,16 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 						zi->oper[1] = SMALL_OR_LARGE(
 							prg->boxclasses[ci->oper[0].value].width |
 							((prg->boxclasses[ci->oper[0].value].flags & BOXF_RELWIDTH)? 0x8000 : 0));
-						zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].style);
-						zi->oper[3] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
+						zi->oper[2] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
 					} else if(prg->boxclasses[ci->oper[0].value].flags & BOXF_FLOATRIGHT) {
 						zi->oper[0] = ROUTINE(R_BEGIN_BOX_RIGHT);
 						zi->oper[1] = SMALL_OR_LARGE(
 							prg->boxclasses[ci->oper[0].value].width |
 							((prg->boxclasses[ci->oper[0].value].flags & BOXF_RELWIDTH)? 0x8000 : 0));
-						zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].style);
-						zi->oper[3] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
+						zi->oper[2] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
 					} else {
 						zi->oper[0] = ROUTINE(R_BEGIN_BOX);
-						zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style);
-						zi->oper[2] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
+						zi->oper[1] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].margintop);
 					}
 				}
 				break;
@@ -2229,7 +2236,8 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 				assert(ci->oper[0].tag == OPER_BOX);
 				zi = append_instr(r, Z_CALL1N);
 				zi->oper[0] = ROUTINE(R_END_STATUS);
-				// Reset colors too, TODO is this right?
+				zi = append_instr(r, Z_CALL1N);
+				zi->oper[0] = ROUTINE(R_END_BOX_STYLE);
 				zi = append_instr(r, Z_CALL1N);
 				zi->oper[0] = ROUTINE(R_RESET_COLORS);
 				break;
@@ -2248,6 +2256,8 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 					zi->oper[1] = SMALL_OR_LARGE(prg->boxclasses[ci->oper[0].value].marginbottom);
 				}
 				// Reset the colors - since we're doing the color-setting in a separate routine, we might as well do the resetting in a separate routine too, even though this could also be called within the various R_END_* routines
+				zi = append_instr(r, Z_CALL1N);
+				zi->oper[0] = ROUTINE(R_END_BOX_STYLE);
 				zi = append_instr(r, Z_CALL1N);
 				zi->oper[0] = ROUTINE(R_RESET_COLORS);
 				break;

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -1833,7 +1833,7 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 					zi = append_instr(r, Z_CALLVN);
 					zi->oper[0] = ROUTINE(R_INIT_BOX_STYLE);
 					zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style | (prg->boxclasses[ci->oper[0].value].unstyle | STYLE_REVERSE ? 0 : STYLE_REVERSE)); // OR STYLE_REVERSE into this value unless STYLE_REVERSE is found in the unstyle value
-					zi->oper[2] = LARGE(~(prg->boxclasses[ci->oper[0].value].unstyle)); // We pass this as a sixteen-bit number instead of an eight-bit number so that it doesn't clobber the top bits of REG_STYLE, which might be used to store something else at some point
+					zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].unstyle);
 					
 					zi = append_instr(r, Z_CALLVN);
 					zi->oper[0] = ROUTINE(R_BEGIN_STATUS);
@@ -1856,7 +1856,7 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 				zi = append_instr(r, Z_CALLVN);
 				zi->oper[0] = ROUTINE(R_INIT_BOX_STYLE);
 				zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style);
-				zi->oper[2] = LARGE(~(prg->boxclasses[ci->oper[0].value].unstyle)); // We pass this as a sixteen-bit number instead of an eight-bit number so that it doesn't clobber the top bits of REG_STYLE, which might be used to store something else at some point
+				zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].unstyle);
 				
 				if(ci->subop == BOX_SPAN) {
 					zi = append_instr(r, Z_CALL1N);

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -1832,7 +1832,7 @@ static void generate_code(struct program *prg, struct routine *r, struct predica
 					// But to replicate the traditional behavior, we're going to apply reverse-video style unless it's specifically been turned off (by setting it in the unstyle value)
 					zi = append_instr(r, Z_CALLVN);
 					zi->oper[0] = ROUTINE(R_INIT_BOX_STYLE);
-					zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style | (prg->boxclasses[ci->oper[0].value].unstyle | STYLE_REVERSE ? 0 : STYLE_REVERSE)); // OR STYLE_REVERSE into this value unless STYLE_REVERSE is found in the unstyle value
+					zi->oper[1] = SMALL(prg->boxclasses[ci->oper[0].value].style | ((prg->boxclasses[ci->oper[0].value].unstyle & STYLE_REVERSE) ? 0 : STYLE_REVERSE)); // OR STYLE_REVERSE into this value unless STYLE_REVERSE is found in the unstyle value
 					zi->oper[2] = SMALL(prg->boxclasses[ci->oper[0].value].unstyle);
 					
 					zi = append_instr(r, Z_CALLVN);

--- a/src/common.h
+++ b/src/common.h
@@ -16,10 +16,11 @@ extern int verbose;
 #define NO_SPACE_BEFORE ".,:;!?)]}>%-"
 #define NO_SPACE_AFTER "([{<-"
 
-#define STYLE_ROMAN	0
+#define STYLE_ROMAN	0 // All styles off
 #define STYLE_REVERSE	1
 #define STYLE_BOLD	2
 #define STYLE_ITALIC	4
 #define STYLE_FIXED	8
 #define STYLE_DEBUG	16
 #define STYLE_INPUT	32
+#define STYLE_INVISIBLE 128 // display:none

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2966,8 +2966,8 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 				(bc->style & STYLE_BOLD)? "yes" :
 				(bc->unstyle & STYLE_BOLD)? "no" : "inherit");
 			printf("\tMonospace:\t%s\n",
-				(bc->style & STYLE_MONOSPACE)? "yes" :
-				(bc->unstyle | STYLE_MONOSPACE)? "no" : "inherit");
+				(bc->style & STYLE_FIXED)? "yes" :
+				(bc->unstyle | STYLE_FIXED)? "no" : "inherit");
 			if(bc->color < 0) { // Print negatives in decimal
 				printf("\tColor:\t%d\n", bc->color);
 			} else { // Positives in hex

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2910,16 +2910,16 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 					}
 				} else if(1 == sscanf(str, "font-style : %s", param)) {
 					if(!strcmp(param, "italic") || !strcmp(param, "oblique")) {
-						bc->style = STYLE_ITALIC;
+						bc->style |= STYLE_ITALIC;
 					}
 				} else if(1 == sscanf(str, "font-weight : %s", param)) {
 					if(!strcmp(param, "bold")) {
-						bc->style = STYLE_BOLD;
+						bc->style |= STYLE_BOLD;
 					}
 				} else if(1 == sscanf(str, "font-family : %s", param)) {
 					// %s stops at first whitespace, so use str:
 					if(strstr(str, "monospace")) {
-						bc->style = STYLE_FIXED;
+						bc->style |= STYLE_FIXED;
 					}
 				} else if(1 == sscanf(str, "color : #%x", &tmp_int)) { // Foreground color, "true" version
 					bc->color = hex_color_to_zcolor(tmp_int);

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2958,7 +2958,7 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 				(bc->flags & BOXF_FLOATRIGHT)? "right" : "none");
 			printf("\tReverse:\t%s\n",
 				(bc->style & STYLE_REVERSE)? "yes" :
-				(bc->unstyle | STYLE_REVERSE)? "no" : "inherit");
+				(bc->unstyle & STYLE_REVERSE)? "no" : "inherit");
 			printf("\tItalic:\t%s\n",
 				(bc->style & STYLE_ITALIC)? "yes" :
 				(bc->unstyle & STYLE_ITALIC)? "no" : "inherit");
@@ -2967,7 +2967,7 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 				(bc->unstyle & STYLE_BOLD)? "no" : "inherit");
 			printf("\tMonospace:\t%s\n",
 				(bc->style & STYLE_FIXED)? "yes" :
-				(bc->unstyle | STYLE_FIXED)? "no" : "inherit");
+				(bc->unstyle & STYLE_FIXED)? "no" : "inherit");
 			if(bc->color < 0) { // Print negatives in decimal
 				printf("\tColor:\t%d\n", bc->color);
 			} else { // Positives in hex

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2911,28 +2911,34 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 				} else if(1 == sscanf(str, "font-style : %s", param)) {
 					if(!strcmp(param, "italic") || !strcmp(param, "oblique")) {
 						bc->style |= STYLE_ITALIC;
-					}else if(!strcmp(param, "normal")) {
+					} else if(!strcmp(param, "normal")) {
 						bc->unstyle |= STYLE_ITALIC;
 					}
 				} else if(1 == sscanf(str, "font-weight : %s", param)) {
 					if(!strcmp(param, "bold")) {
 						bc->style |= STYLE_BOLD;
-					}else if(!strcmp(param, "normal")) {
+					} else if(!strcmp(param, "normal")) {
 						bc->unstyle |= STYLE_BOLD;
 					}
 				} else if(1 == sscanf(str, "font-family : %s", param)) {
 					// %s stops at first whitespace, so use str instead
 					if(strstr(str, "monospace")) {
 						bc->style |= STYLE_FIXED;
-					}else if(strcmp(param, "inherit")) { // Something that's not monospace was specified, and it was *not* inherit
+					} else if(strcmp(param, "inherit")) { // Something that's not monospace was specified, and it was *not* inherit
 						bc->unstyle |= STYLE_FIXED;
 					}
 				} else if(1 == sscanf(str, "font-decoration : %s", param)) {
 					if(strstr(str, "reverse")) { // This is not a standard CSS property, but there is no standard CSS property for reverse video, and unrecognized property values are explicitly not an error in CSS
 						bc->style |= STYLE_REVERSE;
-					}else if(strcmp(param, "inherit")) { // As above, something that's not reverse was specified, and it's *not* inherit
+					} else if(strcmp(param, "inherit")) { // As above, something that's not reverse was specified, and it's *not* inherit
 						bc->unstyle |= STYLE_REVERSE;
 					}
+				} else if(1 == sscanf(str, "display : %s", param)) {
+					if(!strcmp(param, "none")) { // display:none indicates that a span/div should be sent to the transcript but not to the screen, like the quote boxes in Trinity
+						bc->style |= STYLE_INVISIBLE;
+					}
+					// Currently we don't have an opposite to this - everything inside a display:none element is hidden in standard CSS, which is what the Å web interpreter uses
+					// But on the Z-machine, it would be possible to do something with the unstyle property to undo this on a child element
 				} else if(1 == sscanf(str, "color : #%x", &tmp_int)) { // Foreground color, "true" version
 					bc->color = hex_color_to_zcolor(tmp_int);
 				} else if(1 == sscanf(str, "color : %s", param)) { // Foreground color, "standard" version
@@ -2968,6 +2974,9 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 			printf("\tMonospace:\t%s\n",
 				(bc->style & STYLE_FIXED)? "yes" :
 				(bc->unstyle & STYLE_FIXED)? "no" : "inherit");
+			if(bc->style & STYLE_INVISIBLE) {
+				printf("\tUndisplayed\n");
+			}
 			if(bc->color < 0) { // Print negatives in decimal
 				printf("\tColor:\t%d\n", bc->color);
 			} else { // Positives in hex

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -659,7 +659,7 @@ struct rtroutine rtroutines[] = {
 			// 0 (param): style(s) to set
 		(struct zinstr []) {
 			{Z_JNZ, {VALUE(REG_FORWORDS)}, 0, RFALSE},
-			{Z_JNZ, {VALUE(REG_STATUSBAR)}, 0, RFALSE},
+		//	{Z_JNZ, {VALUE(REG_STATUSBAR)}, 0, RFALSE},
 			{Z_TEXTSTYLE, {SMALL(0)}},
 			{Z_TEXTSTYLE, {VALUE(REG_LOCAL+0)}},
 			{Z_RFALSE},
@@ -3514,7 +3514,7 @@ struct rtroutine rtroutines[] = {
 	//		{Z_TEXTSTYLE, {SMALL(0)}}, // Turn off all text styles
 	//		{Z_TEXTSTYLE, {SMALL(1)}}, // Turn on reverse video style
 			// We're now leaving this for authors to handle instead
-			{Z_CALL1N, {ROUTINE(R_RESET_STYLE)}},
+			{Z_CALL1N, {ROUTINE(R_RESET_STYLE)}}, //Turn on whichever styles are currently set
 
 			{OP_LABEL(7)},
 			{Z_SET_CURSOR, {VALUE(REG_LOCAL+0), SMALL(1)}},
@@ -3573,7 +3573,7 @@ struct rtroutine rtroutines[] = {
 	},
 	{
 		R_BEGIN_BOX_LEFT,
-		3,
+		2,
 			// 0 (param): width (msb indicates relative)
 			// 1 (param): top margin
 		(struct zinstr []) {
@@ -3615,7 +3615,7 @@ struct rtroutine rtroutines[] = {
 	},
 	{
 		R_BEGIN_BOX_RIGHT,
-		3,
+		2,
 			// 0 (param): width (msb indicates relative)
 			// 1 (param): top margin
 		(struct zinstr []) {

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -671,11 +671,11 @@ struct rtroutine rtroutines[] = {
 		2,
 			// 0 (param): styles to set for this box class
 			// 1 (param): styles to unset for this box class
-			//		(The compiler takes care of inverting the second one for us)
 		(struct zinstr []) {
 			{Z_CALL2N, {ROUTINE(R_AUX_PUSH1), VALUE(REG_STYLE)}}, // Save the previous value of REG_STYLE
+			{Z_NOT, {VALUE(REG_LOCAL+1)}, REG_LOCAL+1},
 			{Z_AND, {VALUE(REG_STYLE), VALUE(REG_LOCAL+1)}, REG_STYLE}, // Unset the bits from the second parameter in REG_STYLE
-			{Z_AND, {VALUE(REG_LOCAL+0), SMALL(0x7F)}, REG_LOCAL+0},
+			{Z_AND, {VALUE(REG_LOCAL+0), SMALL(0x7f)}, REG_LOCAL+0},
 			{Z_OR, {VALUE(REG_STYLE), VALUE(REG_LOCAL+0)}, REG_STYLE}, // Then set the low bits from the first parameter - this means we can have a style class that e.g. unsets italic, sets bold, and leaves reverse-video untouched
 	//		{Z_CALL1N, {ROUTINE(R_RESET_STYLE)}}, // And apply REG_STYLE to the text
 				// This will be called immediately after by R_BEGIN_whatever, no reason to call it twice
@@ -695,7 +695,7 @@ struct rtroutine rtroutines[] = {
 	},
 	{
 		R_SET_COLORS,
-		3,
+		2,
 			// 0 (param): foreground color to use
 			// 1 (param): background color to use
 		(struct zinstr []) {

--- a/src/zcode.h
+++ b/src/zcode.h
@@ -248,7 +248,7 @@ struct zinstr {
 // 0x15: SOUND_EFFECT
 #define Z_READCHAR	(ZVAR | 0x16)
 #define Z_SCANTABLE	(ZVAR | 0x17)
-// 0x18: NOT
+#define Z_NOT (ZVAR | 0x18)
 #define Z_CALLVN	(ZVAR | 0x19)
 // 0x1a: CALL_VN2 (the version that takes up to 7 args instead of up to 3)
 #define Z_TOKENISE	(ZVAR | 0x1b)

--- a/src/zcode.h
+++ b/src/zcode.h
@@ -382,6 +382,8 @@ enum { // Runtime routines
 	R_RESET_STYLE,
 	R_SET_STYLE,
 	
+	R_INIT_BOX_STYLE,
+	R_END_BOX_STYLE,
 	R_SET_COLORS,
 	R_RESET_COLORS,
 

--- a/src/zcode.h
+++ b/src/zcode.h
@@ -81,7 +81,7 @@ struct zinstr {
 #define REG_STACK		0x00 // Register 0 means push to or pop from the stack
 #define REG_LOCAL		0x01 // The first 15 registers are local to the current routine
 
-#define REG_TEMP		0x10
+#define REG_TEMP		0x10	// Used as scratch space by the compiler
 #define REG_SPACE		0x11	/* see above */
 #define REG_CONT		0x12	/* where to jump after successful end of clause */
 #define REG_ENV			0x13	/* current env frame, unpacked before tail call */


### PR DESCRIPTION
Expands the Z-machine style system in four ways:
- The CSS property `text-decoration: reverse;` sets reverse-video style
- A single style class can now set multiple styles, like bold italics
- Styles can be inherited between spans and divs; a bold span inside an italic span will be bold italic, unless the inner span explicitly specifies not italic
- Styles work normally in the upper window; reverse-video is applied by default, but can be turned off with `text-decoration: none;` (though note that the upper window is always monospace and this can never be turned off per the Z-machine standard)