### PR TITLE
Fix signed comparison bug in Z-machine runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dialogc
 *.z8
 *.zblorb
 *.aastory
+*.log

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -4689,12 +4689,14 @@ void backend_z(
 		uint16_t addr = global_labels[datatable[i].label];
 		if(verbose >= 3) printf("Datatable #%d, length %d, address %04x", i, datatable[i].length, global_labels[datatable[i].label]);
 		for(j = 0; j < datatable[i].length; j++) {
-			if(verbose >= 3 && k % 4 == 0 && !(k & 0x80)) printf("\n\t");
+			if(verbose >= 3 && k % 4 == 0 && !(k & 0x80) && j!=0) printf("\n\t");
 			zcore[addr++] = datatable[i].data[j];
 			if(verbose >= 3) {
 				// One byte if less than 0xe0
 				// Otherwise, 0xe0 | high byte, then low byte
-				if(k & 0x80) {
+				if(j == 0) {
+					// The first byte is the length of the table, not an object number
+				} else if(k & 0x80) {
 					// Nothing
 					k &= 0x7f;
 				} else if(datatable[i].data[j] >= 0xe0) { // High byte

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -3427,6 +3427,7 @@ struct rtroutine rtroutines[] = {
 
 			// For a known word, push a number of objects and return true.
 			{Z_JG, {VALUE(REG_LOCAL+1), REF(G_OBJECT_ID_END)}, 0, 2},
+			{Z_JL, {VALUE(REG_LOCAL+1), SMALL(0)}, 0, 2}, // This is a signed comparison, and values ≥ $8000 should also be interpreted as pointers, not as object numbers!
 
 			// Special treatment for single-element lists: The
 			// object table is located before the wordmaps, so


### PR DESCRIPTION
R_WORDMAP was comparing addresses to object numbers using the standard Z-machine JG opcode. Unfortunately, this opcode does signed comparison, so any addresses above 0x8000 would be treated as negative, and thus considered to be object numbers.

One line of code in the runtime fixed this, but I've also added various tracing instrumentation to the compiler in order to find the problem in the first place.