### PR TITLE
Fix nonlinear unification bugs

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -627,7 +627,8 @@ static void comp_value_into(struct clause *cl, struct astnode *an, value_t dest,
 			ci->oper[0] = dest;
 		}
 	} else if(an->kind == AN_PAIR) {
-		for(i = 0; i < 2; i++) {
+		for(uint8_t j = 2; j > 0; j--) {
+			i = j - 1;
 			if(an->children[i]->kind == AN_VARIABLE) {
 				if(an->children[i]->word->name[0]) {
 					vnum = findvar(cl, an->children[i]->word);

--- a/src/compile.c
+++ b/src/compile.c
@@ -627,8 +627,7 @@ static void comp_value_into(struct clause *cl, struct astnode *an, value_t dest,
 			ci->oper[0] = dest;
 		}
 	} else if(an->kind == AN_PAIR) {
-		for(uint8_t j = 2; j > 0; j--) {
-			i = j - 1;
+		for(i = 1; i >= 0; i--) { // Visit in the opposite order to ensure that, if the same variable appears twice in the pair, the *second* one (i.e. the one that'll be compiled first) is the one that allocates the new reference
 			if(an->children[i]->kind == AN_VARIABLE) {
 				if(an->children[i]->word->name[0]) {
 					vnum = findvar(cl, an->children[i]->word);

--- a/src/eval.c
+++ b/src/eval.c
@@ -1309,6 +1309,7 @@ static int eval_builtin(struct eval_state *es, int builtin, value_t o1, value_t 
 	return 0;
 }
 
+/* // This was introduced to debug the nonlinear unification issue and should be no longer needed
 struct opinfosrc {
 	uint8_t		op;
 	uint8_t		refs; // what operands are dest refs
@@ -1430,7 +1431,7 @@ char* opcode_name(uint8_t op){
 		if(tmp_opinfosrc[i].op == op) return tmp_opinfosrc[i].name;
 	}
 	return "(unknown)";
-}
+} */
 
 static int eval_run(struct eval_state *es) {
 	prgpoint_t pp;
@@ -1469,7 +1470,6 @@ static int eval_run(struct eval_state *es) {
 		}
 		ci = &pp.pred->routines[pp.routine].instr[pc];
 		pc++;
-		printf("*** %s %s\n", pp.pred->predname->printed_name, opcode_name(ci->op));
 		switch(ci->op) {
 		case I_ALLOCATE:
 			assert(ci->oper[0].tag == OPER_NUM);
@@ -2444,20 +2444,20 @@ static int eval_run(struct eval_state *es) {
 			break;
 		case I_MAKE_PAIR_VV:
 			v = alloc_heap_pair(es);
-			printf("*** Allocated heap pair\n");
+	//		printf("*** Allocated heap pair\n");
 			if(v.tag == VAL_ERROR) {
 				pred_release(pp.pred);
 				return ESTATUS_ERR_HEAP;
 			}
-			printf("*** Oper 1: %d %d\n", ci->oper[1].tag, ci->oper[1].value);
+	//		printf("*** Oper 1: %d %d\n", ci->oper[1].tag, ci->oper[1].value);
 			es->heap[v.value + 0] = value_of(ci->oper[1], es);
-			printf("*** Oper 1: %d\n", ci->oper[1].tag, ci->oper[1].value, es->heap[v.value+0]);
-			printf("*** Oper 2: %d %d\n", ci->oper[2].tag, ci->oper[2].value);
+	//		printf("*** Oper 1: %d\n", ci->oper[1].tag, ci->oper[1].value, es->heap[v.value+0]);
+	//		printf("*** Oper 2: %d %d\n", ci->oper[2].tag, ci->oper[2].value);
 			es->heap[v.value + 1] = value_of(ci->oper[2], es);
-			printf("*** Oper 2: %d\n", es->heap[v.value+1]);
-			printf("*** Oper 0: %d %d\n", ci->oper[0].tag, ci->oper[0].value);
+	//		printf("*** Oper 2: %d\n", es->heap[v.value+1]);
+	//		printf("*** Oper 0: %d %d\n", ci->oper[0].tag, ci->oper[0].value);
 			set_by_ref(ci->oper[0], v, es);
-			printf("*** Set by ref\n");
+	//		printf("*** Set by ref\n");
 			break;
 		case I_MAKE_VAR:
 			v = eval_makevar(es);
@@ -3064,9 +3064,9 @@ static int eval_run(struct eval_state *es) {
 			}
 			break;
 		case I_UNIFY:
-			printf("*** Unify:\n");
-			printf("*** oper[0] %d %d\n", ci->oper[0].tag, ci->oper[0].value);
-			printf("*** oper[1] %d %d\n", ci->oper[1].tag, ci->oper[1].value);
+	//		printf("*** Unify:\n");
+	//		printf("*** oper[0] %d %d\n", ci->oper[0].tag, ci->oper[0].value);
+	//		printf("*** oper[1] %d %d\n", ci->oper[1].tag, ci->oper[1].value);
 			if(!unify(es, value_of(ci->oper[0], es), value_of(ci->oper[1], es), 0)) {
 				do_fail(es, &pp);
 				pc = 0;

--- a/src/eval.c
+++ b/src/eval.c
@@ -1309,130 +1309,6 @@ static int eval_builtin(struct eval_state *es, int builtin, value_t o1, value_t 
 	return 0;
 }
 
-/* // This was introduced to debug the nonlinear unification issue and should be no longer needed
-struct opinfosrc {
-	uint8_t		op;
-	uint8_t		refs; // what operands are dest refs
-	uint8_t		flags;
-	char		*name;
-} tmp_opinfosrc[N_OPCODES] = {
-	{I_ALLOCATE,		0, 0,					"ALLOCATE"},
-	{I_ASSIGN,		1, 0,					"ASSIGN"},
-	{I_BEGIN_AREA,		0, OPF_SUBOP|OPF_CAN_FAIL,		"BEGIN_AREA"},
-	{I_BEGIN_AREA_OVERRIDE,		0, OPF_SUBOP|OPF_CAN_FAIL,		"BEGIN_AREA_OVERRIDE"},
-	{I_BEGIN_BOX,		0, OPF_SUBOP|OPF_CAN_FAIL,		"BEGIN_BOX"},
-	{I_BEGIN_LINK,		0, 0,					"BEGIN_LINK"},
-	{I_BEGIN_LINK_RES,	0, 0,					"BEGIN_LINK_RES"},
-	{I_BEGIN_LOG,		0, 0,					"BEGIN_LOG"},
-	{I_BEGIN_SELF_LINK,	0, 0,					"BEGIN_SELF_LINK"},
-	{I_BREAKPOINT,		0, OPF_ENDS_ROUTINE,			"BREAKPOINT"},
-	{I_BUILTIN,		0, 0,					"BUILTIN"},
-	{I_CHECK_INDEX,		0, 0,					"CHECK_INDEX"},
-	{I_CHECK_WORDMAP,	0, 0,					"CHECK_WORDMAP"},
-	{I_CLRALL_OFLAG,	0, 0,					"CLRALL_OFLAG"},
-	{I_CLRALL_OVAR,		0, 0,					"CLRALL_OVAR"},
-	{I_COLLECT_BEGIN,	0, OPF_SUBOP,				"COLLECT_BEGIN"},
-	{I_COLLECT_CHECK,	0, OPF_CAN_FAIL,			"COLLECT_CHECK"},
-	{I_COLLECT_END_R,	1, OPF_SUBOP|OPF_CAN_FAIL,		"COLLECT_END_R"},
-	{I_COLLECT_END_V,	0, OPF_SUBOP|OPF_CAN_FAIL,		"COLLECT_END_V"},
-	{I_COLLECT_MATCH_ALL,	0, OPF_CAN_FAIL,			"COLLECT_MATCH_ALL"},
-	{I_COLLECT_PUSH,	0, OPF_SUBOP,				"COLLECT_PUSH"},
-	{I_COMPUTE_R,		4, OPF_CAN_FAIL|OPF_SUBOP,		"COMPUTE_R"},
-	{I_COMPUTE_V,		0, OPF_CAN_FAIL|OPF_SUBOP,		"COMPUTE_V"},
-	{I_CUT_CHOICE,		0, 0,					"CUT_CHOICE"},
-	{I_DEALLOCATE,		0, OPF_SUBOP,				"DEALLOCATE"},
-	{I_EMBED_RES,		0, 0,					"EMBED_RES"},
-	{I_END_AREA,		0, OPF_SUBOP,				"END_AREA"},
-	{I_END_BOX,		0, OPF_SUBOP,				"END_BOX"},
-	{I_END_LINK,		0, 0,					"END_LINK"},
-	{I_END_LINK_RES,	0, 0,					"END_LINK_RES"},
-	{I_END_LOG,		0, 0,					"END_LOG"},
-	{I_END_SELF_LINK,	0, 0,					"END_SELF_LINK"},
-	{I_FIRST_CHILD,		2, OPF_CAN_FAIL,			"FIRST_CHILD"},
-	{I_FIRST_OFLAG,		2, OPF_CAN_FAIL,			"FIRST_OFLAG"},
-	{I_FOR_WORDS,		0, OPF_SUBOP,				"FOR_WORDS"},
-	{I_GET_GVAR_R,		2, OPF_CAN_FAIL,			"GET_GVAR_R"},
-	{I_GET_GVAR_V,		0, OPF_CAN_FAIL,			"GET_GVAR_V"},
-	{I_GET_INPUT,		0, OPF_CAN_FAIL|OPF_ENDS_ROUTINE,	"GET_INPUT"},
-	{I_GET_KEY,		0, OPF_CAN_FAIL|OPF_ENDS_ROUTINE,	"GET_KEY"},
-	{I_GET_OVAR_R,		4, OPF_CAN_FAIL,			"GET_OVAR_R"},
-	{I_GET_OVAR_V,		0, OPF_CAN_FAIL,			"GET_OVAR_V"},
-	{I_GET_PAIR_RR,		6, OPF_CAN_FAIL,			"GET_PAIR_RR"},
-	{I_GET_PAIR_RV,		2, OPF_CAN_FAIL,			"GET_PAIR_RV"},
-	{I_GET_PAIR_VR,		4, OPF_CAN_FAIL,			"GET_PAIR_VR"},
-	{I_GET_PAIR_VV,		0, OPF_CAN_FAIL,			"GET_PAIR_VV"},
-	{I_GET_RAW_INPUT,	0, OPF_CAN_FAIL|OPF_ENDS_ROUTINE,	"GET_RAW_INPUT"},
-	{I_IF_BOUND,		0, OPF_BRANCH,				"IF_BOUND"},
-	{I_IF_CAN_EMBED,	0, OPF_BRANCH,				"IF_CAN_EMBED"},
-	{I_IF_GREATER,		0, OPF_BRANCH,				"IF_GREATER"},
-	{I_IF_HAVE_LINK,	0, OPF_BRANCH,				"IF_HAVE_LINK"},
-	{I_IF_HAVE_UNDO,	0, OPF_BRANCH,				"IF_HAVE_UNDO"},
-	{I_IF_HAVE_QUIT,	0, OPF_BRANCH,				"IF_HAVE_QUIT"},
-	{I_IF_HAVE_STATUS,	0, OPF_BRANCH,				"IF_HAVE_STATUS"},
-	{I_IF_MATCH,		0, OPF_BRANCH,				"IF_MATCH"},
-	{I_IF_NIL,		0, OPF_BRANCH,				"IF_NIL"},
-	{I_IF_NUM,		0, OPF_BRANCH,				"IF_NUM"},
-	{I_IF_OBJ,		0, OPF_BRANCH,				"IF_OBJ"},
-	{I_IF_PAIR,		0, OPF_BRANCH,				"IF_PAIR"},
-	{I_IF_UNIFY,		0, OPF_BRANCH,				"IF_UNIFY"},
-	{I_IF_WORD,		0, OPF_BRANCH,				"IF_WORD"},
-	{I_IF_UNKNOWN_WORD,	0, OPF_BRANCH,				"IF_UNKNOWN_WORD"},
-	{I_IF_GFLAG,		0, OPF_BRANCH,				"IF_GFLAG"},
-	{I_IF_OFLAG,		0, OPF_BRANCH,				"IF_OFLAG"},
-	{I_IF_GVAR_EQ,		0, OPF_BRANCH,				"IF_GVAR_EQ"},
-	{I_IF_OVAR_EQ,		0, OPF_BRANCH,				"IF_OVAR_EQ"},
-	{I_INVOKE_MULTI,	0, OPF_ENDS_ROUTINE,			"INVOKE_MULTI"},
-	{I_INVOKE_ONCE,		0, OPF_ENDS_ROUTINE,			"INVOKE_ONCE"},
-	{I_INVOKE_TAIL_MULTI,	0, OPF_ENDS_ROUTINE,			"INVOKE_TAIL_MULTI"},
-	{I_INVOKE_TAIL_ONCE,	0, OPF_SUBOP|OPF_ENDS_ROUTINE,		"INVOKE_TAIL_ONCE"},
-	{I_JOIN_WORDS,		2, OPF_CAN_FAIL,			"JOIN_WORDS"},
-	{I_JUMP,		0, OPF_ENDS_ROUTINE,			"JUMP"},
-	{I_MAKE_PAIR_RR,	7, 0,					"MAKE_PAIR_RR"},
-	{I_MAKE_PAIR_RV,	3, 0,					"MAKE_PAIR_RV"},
-	{I_MAKE_PAIR_VR,	5, 0,					"MAKE_PAIR_VR"},
-	{I_MAKE_PAIR_VV,	1, 0,					"MAKE_PAIR_VV"},
-	{I_MAKE_VAR,		1, 0,					"MAKE_VAR"},
-	{I_NEXT_CHILD_PUSH,	0, 0,					"NEXT_CHILD_PUSH"},
-	{I_NEXT_OBJ_PUSH,	0, 0,					"NEXT_OBJ_PUSH"},
-	{I_NEXT_OFLAG_PUSH,	0, 0,					"NEXT_OFLAG_PUSH"},
-	{I_NOP,			0, 0,					"NOP"},
-	{I_NOP_DEBUG,		0, 0,					"NOP_DEBUG"},
-	{I_POP_CHOICE,		0, 0,					"POP_CHOICE"},
-	{I_POP_STOP,		0, 0,					"POP_STOP"},
-	{I_PREPARE_INDEX,	0, 0,					"PREPARE_INDEX"},
-	{I_PRINT_VAL,		0, 0,					"PRINT_VAL"},
-	{I_PRINT_WORDS,		0, OPF_SUBOP,				"PRINT_WORDS"},
-	{I_PROCEED,		0, OPF_SUBOP|OPF_ENDS_ROUTINE,		"PROCEED"},
-	{I_PUSH_CHOICE,		0, 0,					"PUSH_CHOICE"},
-	{I_PUSH_STOP,		0, 0,					"PUSH_STOP"},
-	{I_QUIT,		0, OPF_ENDS_ROUTINE,			"QUIT"},
-	{I_RESTART,		0, OPF_ENDS_ROUTINE,			"RESTART"},
-	{I_RESTORE,		0, 0,					"RESTORE"},
-	{I_RESTORE_CHOICE,	0, 0,					"RESTORE_CHOICE"},
-	{I_SAVE_CHOICE,		1, OPF_SUBOP,				"SAVE_CHOICE"},
-	{I_SAVE,		0, OPF_CAN_FAIL|OPF_ENDS_ROUTINE,	"SAVE"},
-	{I_SAVE_UNDO,		0, OPF_CAN_FAIL|OPF_ENDS_ROUTINE,	"SAVE_UNDO"},
-	{I_SELECT,		0, OPF_SUBOP,				"SELECT"},
-	{I_SET_CONT,		0, 0,					"SET_CONT"},
-	{I_SET_GFLAG,		0, OPF_SUBOP,				"SET_GFLAG"},
-	{I_SET_GVAR,		0, 0,					"SET_GVAR"},
-	{I_SET_OFLAG,		0, OPF_SUBOP,				"SET_OFLAG"},
-	{I_SET_OVAR,		0, 0,					"SET_OVAR"},
-	{I_SPLIT_LIST,		0, 0,					"SPLIT_LIST"},
-	{I_SPLIT_WORD,		2, OPF_CAN_FAIL,			"SPLIT_WORD"},
-	{I_STOP,		0, OPF_ENDS_ROUTINE,			"STOP"},
-	{I_TRACEPOINT,		0, OPF_SUBOP,				"TRACEPOINT"},
-	{I_TRANSCRIPT,		0, OPF_CAN_FAIL,			"TRANSCRIPT"},
-	{I_UNDO,		0, OPF_CAN_FAIL,			"UNDO"},
-	{I_UNIFY,		0, OPF_CAN_FAIL,			"UNIFY"},
-};
-char* opcode_name(uint8_t op){
-	for(uint8_t i=0; i<N_OPCODES; i++){
-		if(tmp_opinfosrc[i].op == op) return tmp_opinfosrc[i].name;
-	}
-	return "(unknown)";
-} */
-
 static int eval_run(struct eval_state *es) {
 	prgpoint_t pp;
 	int i, j, n, res;
@@ -2444,20 +2320,13 @@ static int eval_run(struct eval_state *es) {
 			break;
 		case I_MAKE_PAIR_VV:
 			v = alloc_heap_pair(es);
-	//		printf("*** Allocated heap pair\n");
 			if(v.tag == VAL_ERROR) {
 				pred_release(pp.pred);
 				return ESTATUS_ERR_HEAP;
 			}
-	//		printf("*** Oper 1: %d %d\n", ci->oper[1].tag, ci->oper[1].value);
 			es->heap[v.value + 0] = value_of(ci->oper[1], es);
-	//		printf("*** Oper 1: %d\n", ci->oper[1].tag, ci->oper[1].value, es->heap[v.value+0]);
-	//		printf("*** Oper 2: %d %d\n", ci->oper[2].tag, ci->oper[2].value);
 			es->heap[v.value + 1] = value_of(ci->oper[2], es);
-	//		printf("*** Oper 2: %d\n", es->heap[v.value+1]);
-	//		printf("*** Oper 0: %d %d\n", ci->oper[0].tag, ci->oper[0].value);
 			set_by_ref(ci->oper[0], v, es);
-	//		printf("*** Set by ref\n");
 			break;
 		case I_MAKE_VAR:
 			v = eval_makevar(es);
@@ -3064,9 +2933,6 @@ static int eval_run(struct eval_state *es) {
 			}
 			break;
 		case I_UNIFY:
-	//		printf("*** Unify:\n");
-	//		printf("*** oper[0] %d %d\n", ci->oper[0].tag, ci->oper[0].value);
-	//		printf("*** oper[1] %d %d\n", ci->oper[1].tag, ci->oper[1].value);
 			if(!unify(es, value_of(ci->oper[0], es), value_of(ci->oper[1], es), 0)) {
 				do_fail(es, &pp);
 				pc = 0;


### PR DESCRIPTION
This fixes a small bug in the compiler that occurred when the same variable appears in two adjacent places in a list literal. In other words, `[$X 0 $X]` doesn't trigger the bug, but `[0 $X $X]` does. When this happened, the _latter_ instance was compiled first, but the _former_ instance allocated the memory for the variable. The result was undefined behavior: on Z-machine it would read uninitialized memory and give unpredictable values, in the debugger it would fail an assertion and crash.

Now, the _latter_ instance allocates the memory, which makes everything better.

Test case 1:
```
(program entry point)
	([$X $X] = [0 1])
	Value of X: $X.
```
Previous output:
> Value of X: 0.

New output:
[Nothing, unification fails.]

Test case 2:
```
(program entry point)
	([$X $X] = $Y)
	Value of Y: $Y.
```
Previous output:
> [$ #room]

(The second value is unpredictable and depends on what's sitting around in memory beforehand.)
New output:
> [$ $]