### PR TITLE
Add --numbered option to show call depth with numbers instead of pipes

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -45,6 +45,8 @@ struct debugger {
 
 static int force_width = 0;
 
+extern int use_numbered_levels; // Defined in eval.c
+
 static void set_oflag(struct dyn_state *ds, int onum, int fnum) {
 	struct dyn_obj *o = &ds->obj[onum];
 
@@ -1288,6 +1290,7 @@ void usage(char *prgname) {
 	fprintf(stderr, "--seed      -s    Specify random seed.\n");
 	fprintf(stderr, "--no-links  -L    Don't show hyperlinks in the output.\n");
 	fprintf(stderr, "--dfquirks  -D    Activate the dumbfrotz-compatible quirks mode.\n");
+	fprintf(stderr, "--numbered  -N    Show call depth with numbers during tracing.\n");
 }
 
 int debugger(int argc, char **argv) {
@@ -1302,6 +1305,7 @@ int debugger(int argc, char **argv) {
 		{"seed", 1, 0, 's'},
 		{"no-links", 0, 0, 'L'},
 		{"dfquirks", 0, 0, 'D'},
+		{"numbered", 0, 0, 'N'},
 		{0, 0, 0, 0}
 	};
 
@@ -1324,7 +1328,7 @@ int debugger(int argc, char **argv) {
 	dbg.timestamps = calloc(argc, sizeof(struct timespec));
 
 	do {
-		opt = getopt_long(argc, argv, "?hVvtnqw:s:LD", longopts, 0);
+		opt = getopt_long(argc, argv, "?hVvtnqw:s:LDN", longopts, 0);
 		switch(opt) {
 			case 0:
 			case '?':
@@ -1357,6 +1361,9 @@ int debugger(int argc, char **argv) {
 				break;
 			case 'D':
 				dfrotz_quirks = 1;
+				break;
+			case 'N':
+				use_numbered_levels = 1;
 				break;
 			default:
 				if(opt >= 0) {

--- a/src/eval.c
+++ b/src/eval.c
@@ -16,6 +16,8 @@
 
 static volatile int interrupted = 0;
 
+int use_numbered_levels = 0; 
+
 void eval_interrupt() {
 	interrupted = 1;
 }
@@ -829,8 +831,13 @@ void trace(struct eval_state *es, int kind, struct predname *predname, value_t *
 		assert(es->env >= 0);
 		if(kind != TR_REPORT) {
 			level = es->envstack[es->env].level;
-			for(i = 0; i < level; i++) {
-				o_print_word("| ");
+			if(use_numbered_levels) {
+				snprintf(buf, sizeof(buf), "|%2d ", level);
+				o_print_word(buf);
+			} else {
+				for(i = 0; i < level; i++) {
+					o_print_word("| ");
+				}
 			}
 		}
 		o_print_word(tracename[kind]);


### PR DESCRIPTION
Normally, tracing in the debugger uses pipe characters to show the depth of the call stack.

```
| FOUND (trace on) unifyfail.dg:13
| QUERY (test) unifyfail.dg:14
| | ENTER (test) unifyfail.dg:1
| | QUERY ([$ $] = $) unifyfail.dg:2
| | FOUND ([$ $] = [$ $]) unifyfail.dg:2
Value of Y: [$ $].
| | QUERY ($ = 24) unifyfail.dg:4
| | FOUND (24 = 24) unifyfail.dg:4
Value of Y: [24 24].
| | QUERY (test again) unifyfail.dg:6
| | | ENTER (test again) unifyfail.dg:8
| | | QUERY ($ = 24) unifyfail.dg:9
| | | FOUND (24 = 24) unifyfail.dg:9
Value of Y: $.
| | FOUND (test again) unifyfail.dg:6
| FOUND (test) unifyfail.dg:14
```

However, this is not very good for screen readers. This pull request adds a `-N` or `--numbered` command-line option that will instead display the call stack depth as a number.

```
| 1 FOUND (trace on) unifyfail.dg:13
| 1 QUERY (test) unifyfail.dg:14
| 2 ENTER (test) unifyfail.dg:1
| 2 QUERY ([$ $] = $) unifyfail.dg:2
| 2 FOUND ([$ $] = [$ $]) unifyfail.dg:2
Value of Y: [$ $].
| 2 QUERY ($ = 24) unifyfail.dg:4
| 2 FOUND (24 = 24) unifyfail.dg:4
Value of Y: [24 24].
| 2 QUERY (test again) unifyfail.dg:6
| 3 ENTER (test again) unifyfail.dg:8
| 3 QUERY ($ = 24) unifyfail.dg:9
| 3 FOUND (24 = 24) unifyfail.dg:9
Value of Y: $.
| 2 FOUND (test again) unifyfail.dg:6
| 1 FOUND (test) unifyfail.dg:14
```

If this option is not provided, there's no change in functionality.