### PR TITLE
Fix issue with punctuation characters within lists

### DIFF
--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -530,7 +530,9 @@ struct rtroutine rtroutines[] = {
 			{Z_PRINTLIT, {}, 0, 0, "["},
 			{Z_STORE, {SMALL(REG_UPPER), SMALL(0)}},
 			{Z_STORE, {SMALL(REG_SPACE), SMALL(1)}},
-			{Z_AND, {VALUE(REG_LOCAL+1), SMALL(1)}, REG_LOCAL+4},
+	//		{Z_AND, {VALUE(REG_LOCAL+1), SMALL(1)}, REG_LOCAL+4},
+			{Z_STORE, {SMALL(REG_LOCAL+4), SMALL(1)}}, // Instead of masking out the $02 flag, we just set the flags to $01, ensuring that dictionary words printed inside a list will always have the + flag set
+			// This ensures that, when printing a list for tracing, punctuation spaces itself appropriately
 
 			{OP_LABEL(19)},
 			{Z_SUB, {VALUE(REG_LOCAL+0), VALUE(REG_4000)}, REG_LOCAL+0},


### PR DESCRIPTION
A one-line change to the Z-machine runtime to fix #46.

The only change is in the routine R_PRINT_VALUE, which is used when printing a list. It now sets the $01 flag when recursing on the elements of that list, ensuring that they'll be printed as debugging words (with `+` marking unknown words and spaces on both sides) rather than printing words (with special spacing rules for punctuation).

Since lists are unlikely to be printed except for testing, this shouldn't lead to any changes in published games, and brings the behavior in line with the debugger and the documentation.