### PR TITLE
Make Unicode characters in multi-character dict words a warning instead of an error

### DIFF
--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -843,15 +843,18 @@ void prepare_dictionary_z(struct program *prg) {
 		} else {
 			(void) utf8_to_zscii(zbuf, sizeof(zbuf), w->name, &uchar, 0);
 			if(uchar) { // Invalid Unicode character
-				if(!zbuf[1]) { // Single-character word - crash, that's not allowed!
+				if(!zbuf[1]) { // Single-character word
+					zbuf[0] = '.'; // Convert to '..'
+					zbuf[1] = '.';
+					zbuf[2] = 0;
 					report(
-						LVL_ERR,
+						LVL_WARN,
 						0,
-						"Unsupported character U+%04x in single-character dictionary word '@%s'.",
+						"Unsupported character U+%04x in single-character dictionary word '@%s'. This character will never be recognized by the parser.",
 						uchar,
 						w->name);
-					exit(1);
-				} else { // Otherwise, it's just a warning
+					uchar = 0;
+				} else { // Multi-character word: replace invalid character with '.'
 					report(
 						LVL_WARN,
 						0,

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -844,6 +844,7 @@ void prepare_dictionary_z(struct program *prg) {
 			(void) utf8_to_zscii(zbuf, sizeof(zbuf), w->name, &uchar, 0);
 			if(uchar) { // Invalid Unicode character
 				if(!zbuf[1]) { // Single-character word
+			//		snprintf(zbuf+1, 6, "%04x", uchar); // Store them as meaningful values in the dictionary for later debugging: .01ff or the like
 					zbuf[0] = '.'; // Convert to '..'
 					zbuf[1] = '.';
 					zbuf[2] = 0;


### PR DESCRIPTION
The Z-machine backend doesn't allow non-ZSCII characters in dictionary words, and previously that was a fatal error. But sometimes the compiler was overzealous about deciding which words belonged in the dictionary, and would disallow perfectly legitimate programs, just because it couldn't prove those words _wouldn't_ somehow end up in the parser.

In particular, if _any_ closure is used in parsing, the compiler can't guarantee that _all_ closures won't be used in parsing. As a result, a Unicode character in any other closure—even one nowhere near the parser—would be forbidden. For example:

```
(program entry point)
	*(repeat forever)
	(line)
	(get input $Words)
	(collect $Obj)
		(determine object $Obj)
			*(object $Obj)
		(from words)
			*(dict $Obj)
		(matching all of $Words)
	(into $List)
	$List
	(query {ašdf})
	(empty $Words) %% Fail and repeat if not empty

#apple
(dict *) apple red fruit

#pear
(dict *) (query {pear})
```

This PR changes that error to a warning, and generates a dictionary word with the Unicode characters replaced with periods. This is a trick used in Inform 6 to create words that can never be parsed, without messing up the Z-machine's dictionary. Now, the compiler will instead warn:

> Warning: Unsupported character U+0161 in dictionary word `@ašdf`. This word will never be recognized by the parser.

But if the author is confident that `@ašdf` will never need to be parsed—like in this case—compilation can continue without a problem.