### PR TITLE
Add a doctest script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ test/regtest/%.zblorb: src/dialogc test/regtest/%.dg stdlib.dg
 test: test/regtest/cloak.zblorb src/dgdebug
 	bin/regtest.py -v --game test/regtest/cloak.zblorb --interpreter dfrotz test/regtest/cloak.regtest
 	make --directory=./test/gosling test
+	bin/test.py doc
 
 .PHONY:		test src/%

--- a/bin/test.py
+++ b/bin/test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python3
+import os
+import argparse
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Set
+
+
+DEFAULT_DGDEBUG = ['src/dgdebug', '--quit', '--width=1000']
+LANG_DOCS = Path('manual/modules/lang')
+LIB_DOCS = Path('manual/modules/lib')
+
+
+@dataclass
+class CodeBlock:
+    file_path: Path
+    line_no: int
+    is_source: bool
+    roles: Set[str]
+    contents: str
+
+
+@dataclass
+class CodeBlockError:
+    block: CodeBlock
+    error: str
+
+
+def parse_blocks(file_path):
+    """
+    Parse out blocks from a given Asciidoc file. This is far from a complete parser;
+    it just supports the syntax that we're using in practice.
+    """
+    blocks = []
+    with open(file_path, 'r', encoding='utf-8') as file:
+        open_block = None
+        is_source = False
+        roles = set()
+        lines = []
+        for line_no, line in enumerate(file):
+            line = line.rstrip()
+            if line == open_block:
+                # Got a matching delimiter; close the open block.
+                blocks.append(CodeBlock(
+                    file_path=file_path,
+                    line_no=line_no,
+                    is_source=is_source,
+                    roles=roles,
+                    contents='\n'.join(lines),
+                ))
+                open_block = None
+                lines.clear()
+            elif open_block:
+                # Add the current line to the open block.
+                lines.append(line)
+            elif line.startswith('['):
+                # Extract just the attributes we care about.
+                # Note that role attributes have two different syntaxes to handle... see
+                # https://docs.asciidoctor.org/asciidoc/latest/attributes/role/#assign-roles-to-blocks
+                line = line.lstrip('[').rstrip(']')
+                is_source = False
+                roles = set()
+                for attr in line.split(','):
+                    if attr == 'source':
+                        is_source = True
+                    elif attr.startswith("."):
+                        roles.add(attr.lstrip('.'))
+                    else:
+                        kv = attr.split('=', 1)
+                        if len(kv) > 1 and kv[0] == 'role':
+                            roles.update(kv[1:])
+            elif line.startswith('```') or line.startswith('----'):
+                # Block delimiter, and we're not in a block: open a fresh one.
+                open_block = line
+            else:
+                # Clear any attributes we've captured from a previous line.
+                is_source = False
+                roles = []
+
+    return blocks
+
+
+def check_blocks(blocks: List[CodeBlock], command_template: List[str | None]):
+    """
+    Check that the given blocks execute as expected, using the provided command template for `dgdebug`.
+    """
+    errors = []
+    for block in blocks:
+        if block.is_source and not block.contents.startswith('\t') and 'fragment' not in block.roles:
+            should_error = 'should-error' in block.roles
+            with tempfile.NamedTemporaryFile(mode='w', suffix=f'.{block.file_path.stem}.dg') as source_file:
+                source_file.write(block.contents)
+                source_file.flush()
+                command = [part if part else source_file.name for part in command_template]
+                process = subprocess.Popen(
+                    command,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True
+                )
+                try:
+                    stdout, _ = process.communicate(timeout=2.0)
+                    return_code = process.returncode
+                    if return_code != 0 and not should_error:
+                        message = f'dgdebug returned error code {return_code}: {stdout}'
+                        for line in stdout.splitlines():
+                            if line.startswith("Error: "):
+                                message = ' '.join(line.split()[1:])
+                                break
+                        errors.append(CodeBlockError(
+                            block=block,
+                            error=message
+                        ))
+                    if return_code == 0 and should_error:
+                        errors.append(CodeBlockError(
+                            block=block,
+                            error='expected error, but dgdebug succeeded'
+                        ))
+                except subprocess.TimeoutExpired:
+                    if not should_error:
+                        errors.append(CodeBlockError(
+                            block=block,
+                            error=f'dgdebug timed out'
+                        ))
+    return errors
+
+
+def check_docs(dir_path, dgdebug_template):
+    """
+    Parse and check all the files in a directory.
+    """
+    paths = sorted(dir_path.glob('**/*.adoc'))
+    errors = []
+    for path in paths:
+        blocks = parse_blocks(path)
+        errors.extend(check_blocks(blocks, dgdebug_template))
+    return errors
+
+
+def doc_command(args):
+    """
+    Implement the `doc` subcommand.
+    """
+    errors = []
+    if args.directory:
+        directory = Path(args.directory)
+        command = list(DEFAULT_DGDEBUG)
+        command.append(None)
+        command.extend(args.library)
+        errors.extend(check_docs(directory, command))
+    else:
+        command = list(DEFAULT_DGDEBUG)
+        command.append(None)
+        errors.extend(check_docs(LANG_DOCS, command))
+        command.append('stdlib.dg')
+        errors.extend(check_docs(LIB_DOCS, command))
+
+    for error in errors:
+        print(f'{error.block.file_path}@{error.block.line_no}: {error.error}')
+
+    exit_code = 1 if errors else 0
+    return exit_code
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Dialog-specific test utility.'
+    )
+    subparsers = parser.add_subparsers(
+        title='subcommands',
+        description='Individual testing commands.',
+        metavar='<command>',
+        dest='command',
+    )
+
+    # Check command
+    check_parser = subparsers.add_parser(
+        'doc',
+        help='Assert that the code blocks in the documentation are valid. '
+             'If no directory is specified, checks the default documentation location.'
+    )
+    check_parser.add_argument(
+        'directory',
+        help='Documentation directory to process.',
+        nargs='?'
+    )
+    check_parser.add_argument(
+        'library',
+        help='Additional library file to include with all examples.',
+        nargs='*',
+        action='append',
+    )
+
+    args = parser.parse_args()
+
+    if args.command == 'doc':
+        return doc_command(args)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/manual/modules/lang/pages/beyondprg.adoc
+++ b/manual/modules/lang/pages/beyondprg.adoc
@@ -229,7 +229,7 @@ The second principle is: Make tail calls. The last statement of a rule body is
 said to be in tail position. Making a query in tail position is cheaper than
 making it elsewhere. Thus, the following implementation:
 
-[source]
+[source,.fragment]
 ----
 (say it with $Obj)	My hovercraft is full of (name $Obj).
 (stash $Obj)		(say it with $Obj) (now) ($Obj is #in #hovercraft)
@@ -239,7 +239,7 @@ link:[[Copy to clipboard]]
 
 is not as efficient as this one:
 
-[source]
+[source,.fragment]
 ----
 (say it with $Obj)	My hovercraft is full of (name $Obj).
 (stash $Obj)		(now) ($Obj is #in #hovercraft) (say it with $Obj)

--- a/manual/modules/lang/pages/builtins.adoc
+++ b/manual/modules/lang/pages/builtins.adoc
@@ -147,7 +147,7 @@ predicate:
 
 [source]
 ----
-(split $Input by $Keyword into $Left and $Right)
+	(split $Input by $Keyword into $Left and $Right)
 ----
 
 `$Input` must be a list of simple values, i.e. it mustn't contain

--- a/manual/modules/lang/pages/builtins.adoc
+++ b/manual/modules/lang/pages/builtins.adoc
@@ -195,13 +195,14 @@ and/or single-digit numbers. Thus:
 
 [source]
 ----
+(program entry point)
 	(split word @fission into $List)
 	$List
 ----
 
 will print:
 
-[role="output"]
+[.output.matches-previous]
 ```
 [f i s s i o n]
 ```
@@ -211,13 +212,14 @@ Conversely, it is possible to construct a dictionary word from a list of words
 
 [source]
 ----
+(program entry point)
 	(join words [f u s i o n] into $Word)
 	$Word
 ----
 
 will print:
 
-[role="output"]
+[.output.matches-previous]
 ```
 fusion
 ```
@@ -236,7 +238,7 @@ It is possible to split and join numbers as though they were words:
 
 [source]
 ----
-	> (get input [$W])
+	(get input [$W])
 	(split word $W into $Chars)
 	(split $Chars by 5 into $LeftChars and $RightChars)
 	$LeftChars, $RightChars. (line)

--- a/manual/modules/lang/pages/choicepoints.adoc
+++ b/manual/modules/lang/pages/choicepoints.adoc
@@ -360,7 +360,7 @@ Checking the oaken door. Checking my left foot. Checking the green apple. Yes, i
 Incidentally, `($ is one of $)` is a built-in predicate for performance reasons only.
 We could have defined it ourselves like this:
 
-[source]
+[source,.should-error]
 ----
 ($Element is one of [$Element | $])
 ($Element is one of [$ | $Tail])
@@ -641,7 +641,7 @@ Code such as `(just) (just)` is redundant; the second `(just)` has no effect.
 The built-in predicate `(repeat forever)` provides an unlimited supply of choice points.
 This can be used to create infinite loops (such as the main game loop or the game-over menu).
 
-[source]
+[source,.should-error]
 ----
 (program entry point)
 	*(repeat forever)

--- a/manual/modules/lang/pages/choicepoints.adoc
+++ b/manual/modules/lang/pages/choicepoints.adoc
@@ -33,6 +33,15 @@ Here is an example:
 (player eats meat)
 ----
 
+The output from the program is:
+
+[.output.matches-previous]
+```
+Apple: Yummy!
+Steak: Yummy!
+Door: You see nothing unexpected about it.
+```
+
 Note that this part of the code:
 
 [source]
@@ -51,15 +60,6 @@ is exactly equivalent to:
 
 (tasty $Obj)	($Obj = #steak) (player eats meat)
 ----
-
-The output from the program is:
-
-[role="output"]
-```
-Apple: Yummy!
-Steak: Yummy!
-Door: You see nothing unexpected about it.
-```
 
 There can be more than two subexpressions in a disjunction;
 just separate them all with `(or)` keywords,
@@ -172,7 +172,7 @@ This can be used to narrate what's going on while the program is searching for a
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Checking the oaken door. Checking my left foot. Checking the green apple. Yes, it's a fruit!
 ```
@@ -221,7 +221,7 @@ Here is an example:
 
 The output of the program is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 #apple is a fruit. #orange is a fruit. We found a fruit that is also a colour!
 ```
@@ -267,7 +267,7 @@ This provides a very powerful mechanism for searching through a database of rela
 
 Output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 The answer is #abraham.
 ```
@@ -352,7 +352,7 @@ Here is a more elegant re-implementation of an earlier example:
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Checking the oaken door. Checking my left foot. Checking the green apple. Yes, it's a fruit!
 ```
@@ -400,7 +400,7 @@ A Dialog statement can be prefixed with the `(exhaust)` keyword. This will cause
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Checking the oaken door.
 Checking my left foot.
@@ -459,7 +459,7 @@ Example:
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Come and buy! [#apple #orange #banana]!
 ```
@@ -515,10 +515,10 @@ Example:
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 The green apple can be referred to using the words [yummy green apple].
-The mysterious door can be referred to using the words [oaken oak mysteriou door].
+The mysterious door can be referred to using the words [oaken oak mysterious door].
 ```
 
 Printed values (numbers, lists, objects) also end up in the collection, as themselves.
@@ -543,7 +543,7 @@ and `(` inhibits whitespace on its right:
 
 produces the output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 The list is: [hello , world!]
 Printing each word: hello, world!
@@ -583,7 +583,7 @@ Thus:
 
 would produce the output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 I know of 3 pieces of fruit.
 ```

--- a/manual/modules/lang/pages/control.adoc
+++ b/manual/modules/lang/pages/control.adoc
@@ -198,7 +198,7 @@ To advance predictably through a series of alternatives, and then stick with the
 
 The output of that program is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 This is printed the first time.
 This is printed the second time.
@@ -252,7 +252,7 @@ Afterwards, the same variable is bound to a dictionary word.
 
 The output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Hello, world!
 ```
@@ -271,7 +271,7 @@ The following program:
 
 produces the following output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Veni! Vidi! Vici!
 ```
@@ -320,7 +320,7 @@ Here is a convoluted example:
 
 The printed output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Let's take this shortcut now.
 ```

--- a/manual/modules/lang/pages/dynamic.adoc
+++ b/manual/modules/lang/pages/dynamic.adoc
@@ -18,14 +18,14 @@ keyword:
 
 [source]
 ----
-    (now) (player eats meat)
+	(now) (player eats meat)
 ----
 
 To clear it, use `(now)` together with a negation:
 
 [source]
 ----
-    (now) ~(player eats meat)
+	(now) ~(player eats meat)
 ----
 
 We are allowed to define static rules for the global flag, but they won't be
@@ -150,7 +150,7 @@ _Global variables_ are dynamic predicates with a single parameter. To
 distinguish them from per-object flags, global variables have to be _declared_,
 using special syntax. This is what it looks like:
 
-[source,subs="quotes"]
+[source,subs="quotes",.should-error]
 ----
 (global variable _(signature)_)
 ----
@@ -182,7 +182,7 @@ To change the value of a global variable, use the `(now)` keyword:
 
 [source]
 ----
-(now) (current player #alice)
+	(now) (current player #alice)
 ----
 
 Note that the above is a low-level operation. When working with the standard

--- a/manual/modules/lang/pages/dynamic.adoc
+++ b/manual/modules/lang/pages/dynamic.adoc
@@ -120,9 +120,9 @@ backtrack over all objects that have the flag set:
 
 This produces the output:
 
-[role="output"]
+[.output.matches-previous]
 ```
-The open things are: [#reddoor #greendoor]
+The open things are: [#greendoor #reddoor]
 ```
 
 Let's pause for a while and consider a matter of design philosophy. I have

--- a/manual/modules/lang/pages/execution.adoc
+++ b/manual/modules/lang/pages/execution.adoc
@@ -70,7 +70,7 @@ Comments in the source code are prefixed with `%%` and last to the end of the li
 
 produces this output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Hello y'all (and "welcome")!
 ```
@@ -78,6 +78,8 @@ Hello y'all (and "welcome")!
 Dialog is smart about punctuation and whitespace:
 It interprets the source code text as a stream of words and punctuation characters, and rebuilds the output from that stream, inserting whitespace as appropriate.
 It knows that no space should precede a comma, that a space should go before an opening parenthesis but not after it, and so on.
+However, Dialog will not insert whitespace when punctuation is written in the middle of a longer word,
+like the apostrophe in "can't".
 
 [source]
 ----
@@ -93,9 +95,9 @@ It knows that no space should precede a comma, that a space should go before an 
 
 The output of that is:
 
-[role="output"]
+[.output.matches-previous]
 ```
-For instance: This text (which, to all intents and purposes, is silly (indeed)), prints properly.
+For instance:This text (which,to all intents and purposes,is silly(indeed)), prints properly.
 ```
 
 It is possible to override the automatic whitespace decisions on a case-by-case basis using the built-in predicates `(space)` and `(no space)`:
@@ -108,7 +110,7 @@ It is possible to override the automatic whitespace decisions on a case-by-case 
 
 The output of that is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 Together , apart.
 ```
@@ -140,7 +142,7 @@ The following program:
 
 produces the following output:
 
-[role="output"]
+[.output.matches-previous]
 ```
 This goes on a line of its own.
 This goes on a line of its own.
@@ -249,7 +251,7 @@ Thus, the program entry point rule will proceed to print “Over and out”.
 
 The complete output is:
 
-[role="output"]
+[.output.matches-previous]
 ```
 It looks yummy! Over and out.
 ```

--- a/manual/modules/lang/pages/execution.adoc
+++ b/manual/modules/lang/pages/execution.adoc
@@ -68,7 +68,7 @@ Comments in the source code are prefixed with `%%` and last to the end of the li
 	Hello y'all \( and "welcome" \) !  %% This is a comment.
 ----
 
-produces this outupt:
+produces this output:
 
 [role="output"]
 ```

--- a/manual/modules/lang/pages/io.adoc
+++ b/manual/modules/lang/pages/io.adoc
@@ -550,7 +550,7 @@ When a resource has been defined, it's possible to link to it using the followin
 
 [source,subs="quotes"]
 ----
-    (link resource $Id) _statement_
+	(link resource $Id) _statement_
 ----
 
 Here is an example:

--- a/manual/modules/lang/pages/varsvalues.adoc
+++ b/manual/modules/lang/pages/varsvalues.adoc
@@ -28,7 +28,7 @@ They are case sensitive.
 
 Since there is no explicit rule definition for `(The #orange)`, the program will print:
 
-[role=output]
+[.output.matches-previous]
 ```
 The green apple looks yummy.
 That looks yummy.
@@ -49,7 +49,7 @@ In the case of objects, this will print the actual hashtag as it appears in the 
 
 This will print:
 
-[role=output]
+[.output.matches-previous]
 ```
 No description for #apple!
 ```
@@ -85,7 +85,7 @@ Here is a very simplistic approach to world modelling:
 
 The output is:
 
-[role=output]
+[.output.matches-previous]
 ```
 Apple: Yummy!
 Door: The oaken door is oaken.
@@ -174,7 +174,7 @@ Printing a list is possible, and highly useful during debugging. The program:
 
 will print out:
 
-[role=output]
+[.output.matches-previous]
 ```
 Have a look at [#this inscrutable list]!
 ```
@@ -200,7 +200,7 @@ The printed representation of an unbound variable is always $, regardless of its
 
 The output is:
 
-[role=output]
+[.output.matches-previous]
 ```
 This list contains an unbound variable: [one $ three]
 ```
@@ -240,7 +240,7 @@ An unbound variable successfully unifies with any value, but this also has the e
 
 will print:
 
-[role=output]
+[.output.matches-previous]
 ```
 I like #apples and #oranges.
 ```
@@ -261,7 +261,7 @@ But once the variable is bound, it sticks to that value:
 
 will print:
 
-[role=output]
+[.output.matches-previous]
 ```
 I like #apples
 ```
@@ -289,7 +289,7 @@ the second anonymous variable is bound to `#apples`,
 and `$X` is bound to `[#apples #pears #oranges]`.
 The output of the program is:
 
-[role=output]
+[.output.matches-previous]
 ```
 I like [#apples #pears #oranges].
 ```
@@ -311,6 +311,7 @@ This has a very interesting and useful consequence, which is that parameters can
 (program entry point)
 	(#rock beats $X)	%% Parameters are: Input, output.
 	When your opponent plays rock, you'd better not play $X.
+	(line)
 	($Y beats #rock)	%% Parameters are: Output, input.
 	When your opponent plays rock, you should play $Y.
 ----
@@ -337,10 +338,10 @@ The rule body is empty, so it succeeds too, and control returns to the top-level
 
 The output of the program is:
 
-[role=output]
+[.output.matches-previous]
 ```
-When your opponent plays rock, you'd better not play #scissors. When your opponent
-plays rock, you should play #paper.
+When your opponent plays rock, you'd better not play #scissors.
+When your opponent plays rock, you should play #paper.
 ```
 
 == Partial lists and recursion
@@ -374,7 +375,7 @@ Here is an example of extracting the head and tail of a list:
 
 Here is the output:
 
-[role=output]
+[.output.matches-previous]
 ```
 A is 1. B is [2 3 4].
 ```
@@ -391,7 +392,7 @@ Unification works both ways, so the same syntax can be used to construct a list 
 
 The output is:
 
-[role=output]
+[.output.matches-previous]
 ```
 Tacking on a new head: [1 2 3 4]
 ```
@@ -411,7 +412,7 @@ So:
 
 produces the following output:
 
-[role=output]
+[.output.matches-previous]
 ```
 The result is [b a c d e].
 ```
@@ -439,7 +440,7 @@ Here is an example that considers each element of a list in turn using recursive
 
 The output is:
 
-[role=output]
+[.output.matches-previous]
 ```
 You see a banana.
 You see an unknown fruit.

--- a/manual/modules/lib/pages/items.adoc
+++ b/manual/modules/lib/pages/items.adoc
@@ -241,7 +241,7 @@ object in the bowl, not just the amethyst and the sapphire. So we have to take
 care of any foreign objects that might end up there too. In some situations, it
 might be sufficient to drop a vague hint:
 
-[console]
+[source]
 ----
 (descr #bowl)
 	It's a small bowl.
@@ -262,7 +262,7 @@ Thus:
 (descr #bowl)
 	It's a small bowl.
 	(par)
-	(list objects #in *)
+	(list objects #in #bowl)
 
 ~(appearance $ #in #bowl)
 ----
@@ -448,7 +448,7 @@ have to define:
 
 [source]
 ----
-(wearing #socks removes #shoes) |
+(wearing #socks removes #shoes)
 ----
 
 But this combination of constraints—`(wearing $A covers $B)` and

--- a/manual/modules/lib/pages/timeprogress.adoc
+++ b/manual/modules/lib/pages/timeprogress.adoc
@@ -411,8 +411,6 @@ the links between nodes:
 
 [source]
 ----
-...
-
 #land
 (label *)	Return back home.
 (disp *)	After an impeccable landing, you find yourself back at the hive.


### PR DESCRIPTION
This adds a script that performs very basic validations of the code in the docs. In particular, it asserts that code blocks can be loaded by `dgdebug` without errors... or, if it's an example that's expected to error, it should complain if `dgdebug` loads the code successfully.

I've also made some changes to the docs themselves:
- Sometimes the code was invalid; those are now fixed.
- Sometimes the code is only valid in the body, but not at the top level. Sometimes we indent those code examples; sometimes we don't. We now always indent such code, and the test script ignores code that starts with an indent.
- Some examples are examples of things not to do. (Infinite loops; invalid syntax; re-declaring builtins.) These are now explicitly annotated. (In a way that hopefully shouldn't change the generated website, though I don't currently have a way to check.) 