### PR TITLE
Build for MacOS and generate a release ZIP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,15 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
+    tags: ['release-*-*']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
-  build:
 
+  build-linux:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
@@ -21,3 +21,84 @@ jobs:
       run: make --directory=./src dgdebug.exe dialogc.exe
     - name: make test
       run: make test
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-x86_64
+        path: |
+          src/dgdebug
+          src/dialogc
+    - uses: actions/upload-artifact@v4
+      with:
+        name: win32
+        path: |
+          src/dgdebug
+          src/dialogc
+          - uses: actions/upload-artifact@v4
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        run: brew install frotz
+      - name: make
+        run: make --directory=./src
+      - name: make test
+        run: make test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64
+          path: |
+            src/dgdebug
+            src/dialogc
+
+  build-release:
+    runs-on: ubuntu-latest
+    needs: ['build-linux', 'build-macos']
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      # TODO: check that the tag matches the version number in the files
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: assemble release bundle
+        # TODO: include generated doc HTML instead of the raw markup
+        run: |
+          # Determine the bundle name, and save it in the persistent environment
+          if [[ "$GITHUB_REF_NAME" == release-* ]]; then
+            BUNDLE=$(echo "$GITHUB_REF_NAME" | sed 's/^release-/dialog-/')
+          else
+            BUNDLE="dialog-prerelease"
+          fi
+          echo "DIALOG_BUNDLE_NAME=$BUNDLE" >> "$GITHUB_ENV"
+          cat "$GITHUB_ENV"
+          # Create the bundle and add the prebuild binaries in
+          mkdir -p "$BUNDLE/prebuilt"
+          mv artifacts/linux-x86_64 "$BUNDLE/prebuilt/"
+          mv artifacts/macos-arm64 "$BUNDLE/prebuilt/"
+          mv artifacts/win32 "$BUNDLE/prebuilt/"
+          chmod +x "$BUNDLE"/prebuilt/*/*
+          # Include all the other relevant files from the release
+          mv prebuilt/win32/* "$BUNDLE/prebuilt/win32/"
+          cp --recursive src "$BUNDLE/"
+          cp --recursive manual/modules "$BUNDLE"/docs
+          cp *.dg "$BUNDLE"/
+          cp *.txt "$BUNDLE"/
+          # Group them together in a single zip
+          zip -r "$BUNDLE".zip "$BUNDLE"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dialog-release
+          path: ${{ env.DIALOG_BUNDLE_NAME }}.zip
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ env.DIALOG_BUNDLE_NAME }}.zip
+          body: >
+            This is a test release: please ignore.
+          draft: true
+          generate_release_notes: true


### PR DESCRIPTION
- Builds and tests on MacOS as well.
- Generates a ZIP which more-or-less approximates Linus' release zips. Differences include a change in supported architectures (intentional) and including the documentation source instead of the generated HTML (unfortunate, but I'd rather not block this until the good stuff is available).

This theoretically will only generate a release if a `release-XXX` tag is pushed. So for example `release-1a01-1.0.0` would generate `dialog-1a01-1.0.0.zip`.

However we do upload the zip for every build, if you want to inspect it. It's a little awkward to navigate to, but if you click the `build-release` link in the checks below, and then the ":house: Summary" link at the top left, the "archives" generated by the build process are downloadable at the bottom. (Though for annoying technical reasons the release zip is itself wrapped up in another zip file... oh well.)
