### PR TITLE
Fix error with serial commas

### DIFF
--- a/stdlib.dg
+++ b/stdlib.dg
@@ -5316,6 +5316,10 @@
 	(object $Head)
 (mark multi-object $Other into $Other)
 
+%% Avoid error when using serial comma (TAKE X, Y, AND Z)
+(parse noun list [and | $Rest] as $ObjList $Policy $AllAllowed)
+	(parse noun list $Rest as $ObjList $Policy $AllAllowed)
+
 (parse noun list $Words as $ObjList $Policy $AllAllowed)
 	(split $Words by [, and] into $Left and $Right)
 	*(parse basic noun $Left as $LeftObj $Policy $AllAllowed)


### PR DESCRIPTION
Previously, using the serial comma led to a parse failure:

> \> take apple, pear, and banana
> You take the apple.
> 
> (I'm sorry, I didn't understand what you wanted to do.)

This is because when parsing a noun list, it splits on the first instance of `@,` or `@and`, then tries to parse the left side as a single object and the right side as potentially multiple objects. With a serial comma, this leads to an empty left side, and thus parsing fails.

A one-line change to the standard library (well, technically two line change) strips a leading `@and` off before parsing, which fixes this issue.

> \> take apple, pear, and banana
> The apple: You take the apple.
> 
> The pear: You take the pear.
> 
> The banana: You take the banana.

This fixes #55 .