### PR TITLE
Backtrack to free memory before final question

### DIFF
--- a/stdlib.dg
+++ b/stdlib.dg
@@ -4776,7 +4776,7 @@
 			(parse commandline $Words with choices [])
 		}
 	(elseif) (game has ended) (then)
-		(actual game over)
+		(game over)
 	(else)
 		(par)
 		(stoppable) {

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -4988,7 +4988,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Game over
 
-(actual game over) %% The (game over) predicate first backtracks to free memory, then calls this
+(game over) %% The (game over $) predicate first backtracks to free memory, then calls this
 	(par)
 	(game over status bar)
 	(if) (scoring enabled) (then)
@@ -5005,15 +5005,12 @@
 
 (interface (game over $<Closure))
 
-(game over)
-	(now) (game has ended)
-	(stop)
-
 (game over $Message)
 	(par)
 	(space 5)
 	(span @bold) { \*\*\* (query $Message) \*\*\* }
-	(game over)
+	(now) (game has ended)
+	(stop)
 
 (game over status bar)
 	(status bar @status) {

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -4775,6 +4775,8 @@
 		(stoppable) {
 			(parse commandline $Words with choices [])
 		}
+	(elseif) (game has ended) (then)
+		(actual game over)
 	(else)
 		(par)
 		(stoppable) {
@@ -4980,13 +4982,13 @@
 
 (story release 1)
 
-(story noun)	
+(story noun)
 	An interactive fiction
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Game over
 
-(game over)
+(actual game over) %% The (game over) predicate first backtracks to free memory, then calls this
 	(par)
 	(game over status bar)
 	(if) (scoring enabled) (then)
@@ -5002,6 +5004,10 @@
 	*(repeat forever) (game over menu) (fail)
 
 (interface (game over $<Closure))
+
+(game over)
+	(now) (game has ended)
+	(stop)
 
 (game over $Message)
 	(par)


### PR DESCRIPTION
Dialog's dynamic memory model is fairly simple. It has no garbage collector, so it only frees memory when backtracking (due to `(fail)` or `(stop)`—the two ways of calling the Z-machine `@throw` opcode in Dialog).

This means that doing multiple parses without backtracking in between can quickly exhaust the heap. This originally became a problem with disambiguation questions, so the standard library (several versions ago) was updated to backtrack before disambiguating and reclaim that memory for the next parse.

This was not done, however, for the final question ("Game over! Do you want to undo, restart, restore, or quit?"), because the parsing there is simplistic enough that it generally doesn't cause a heap overflow. But if any complicated code is added to the final question, it will quickly crash the interpreter—this happened with the automap in _Familiar Problems_.

Since the backtracking code was already added for disambiguation questions, it takes only a couple lines of code to make the final question use it too. Now you can get as complicated as you like during the final question, without overflowing the heap.