### PR TITLE
Add (ambiguously plural $) trait

### DIFF
--- a/stdlib.dg
+++ b/stdlib.dg
@@ -327,6 +327,7 @@
 
 %% These are typically static traits:
 
+(ambiguously plural $)	(fail)
 (an $)			(fail)
 (door $)		(fail)
 (edible $)		(fail)
@@ -4427,19 +4428,39 @@
 (notice $Obj)
 	(if) (object $Obj) (then)
 		(reveal $Obj)
-		(if) (plural $Obj) (or) (pair $Obj) (or) (gender-neutral $Obj) (then)
+		
+		%% Should we set plural pronouns?
+		(if)
+			(ambiguously plural $Obj) (or)
+			(plural $Obj) (or)
+			(pair $Obj) (or)
+			(gender-neutral $Obj)
+		(then)
 			(now) (them refers to [$Obj])
-		(elseif) (female $Obj) (then)
-			(now) (her refers to $Obj)
-		(elseif) (male $Obj) (then)
-			(now) (him refers to $Obj)
-		(else)
-			(now) (narrator's it refers to $Obj)
-			(now) (narrator's it is protected)
-			(if) (player's it refers to $Obj) (then)
-				(now) ~(player's it refers to $)
+		(endif)
+		
+		%% Should we set singular pronouns?
+		(if)
+			(ambiguously plural $Obj) (or)
+			~{
+				(plural $Obj) (or)
+				(pair $Obj) (or)
+				(gender-neutral $Obj)
+			}
+		(then)
+			(if) (female $Obj) (then)
+				(now) (her refers to $Obj)
+			(elseif) (male $Obj) (then)
+				(now) (him refers to $Obj)
+			(else)
+				(now) (narrator's it refers to $Obj)
+				(now) (narrator's it is protected)
+				(if) (player's it refers to $Obj) (then)
+					(now) ~(player's it refers to $)
+				(endif)
 			(endif)
 		(endif)
+		
 	(elseif) (list $Obj) (then)
 		(if) ($Obj = [$Single]) (then)
 			(notice $Single)
@@ -4450,23 +4471,46 @@
 
 (notice player's $Obj)
 	(if) ~(current player $Obj) (then)
-		(if) (plural $Obj) (or) (pair $Obj) (or) (gender-neutral $Obj) (then)
-			(now) (them refers to [$Obj])
-		(elseif) (list $Obj) (then)
+		
+		(if) (list $Obj) (then)
 			(if) ($Obj = [$Single]) (then)
 				(notice player's $Single)
 			(else)
 				(now) (them refers to $Obj)
 			(endif)
-		(elseif) (female $Obj) (then)
-			(now) (her refers to $Obj)
-		(elseif) (male $Obj) (then)
-			(now) (him refers to $Obj)
 		(else)
-			(now) (player's it refers to $Obj)
-			(if) (narrator's it refers to $Obj) (then)
-				(now) ~(narrator's it refers to $)
+			
+			%% Should we set plural pronouns?
+			(if)
+				(ambiguously plural $Obj) (or)
+				(plural $Obj) (or)
+				(pair $Obj) (or)
+				(gender-neutral $Obj)
+			(then)
+				(now) (them refers to [$Obj])
 			(endif)
+			
+			%% Should we set singular pronouns?
+			(if)
+				(ambiguously plural $Obj) (or)
+				~{
+					(plural $Obj) (or)
+					(pair $Obj) (or)
+					(gender-neutral $Obj)
+				}
+			(then)
+				(if) (female $Obj) (then)
+					(now) (her refers to $Obj)
+				(elseif) (male $Obj) (then)
+					(now) (him refers to $Obj)
+				(else)
+					(now) (player's it refers to $Obj)
+					(if) (narrator's it refers to $Obj) (then)
+						(now) ~(narrator's it refers to $)
+					(endif)
+				(endif)
+			(endif)
+		
 		(endif)
 	(endif)
 

--- a/test/simple/library/new_ambigplural.dg
+++ b/test/simple/library/new_ambigplural.dg
@@ -1,0 +1,19 @@
+(current player #me)
+(#me is #in #room)
+(room #room)
+
+#deck
+(name *) deck of cards
+(dict *) card
+(* is #in #room)
+(ambiguously plural *)
+
+#box
+(name *) box
+(* is #in #room)
+
+#candy
+(name *) candy
+(plural *)
+(* is #in #room)
+(ambiguously plural *)

--- a/test/simple/library/new_ambigplural.gold
+++ b/test/simple/library/new_ambigplural.gold
@@ -1,0 +1,47 @@
+[Z] Location
+[Z]
+An Interactive Fiction
+An interactive fiction by Anonymous.
+Release 1. Serial number <SERIAL>.
+<COMPILER>. <LIBRARY>
+
+Location
+You are here.
+
+> x cards
+[Z] Location
+[Z]
+It seems to be harmless.
+
+> pronouns
+[Z] Location
+[Z]
+"Me" refers to yourself.
+"It" refers to the deck of cards.
+"Them" refers to the deck of cards.
+
+> x box
+[Z] Location
+[Z]
+It seems to be harmless.
+
+> pronouns
+[Z] Location
+[Z]
+"Me" refers to yourself.
+"It" refers to the box.
+"Them" refers to the deck of cards.
+
+> x candy
+[Z] Location
+[Z] 
+They seem to be harmless.
+
+> pronouns
+[Z] Location
+[Z] 
+"Me" refers to yourself.
+"It" refers to the candy.
+"Them" refers to the candy.
+
+>

--- a/test/simple/library/new_ambigplural.in
+++ b/test/simple/library/new_ambigplural.in
@@ -1,0 +1,6 @@
+x cards
+pronouns
+x box
+pronouns
+x candy
+pronouns


### PR DESCRIPTION
Mirroring Inform, an `(ambiguously plural $)` object sets both singular and plural pronouns. If it also has a trait like `(plural $)`, it will use plural pronouns; otherwise, it will use singular ones. Either way, both THEM and the appropriate one of HIM/HER/IT will be set to it.

This also allows THEM to be set to a person without making them gender-neutral, mitigating the issues created by fixing #72 .