### PR TITLE
Add (initial appearance $) predicate

### DIFF
--- a/manual/modules/lib/pages/items.adoc
+++ b/manual/modules/lib/pages/items.adoc
@@ -319,6 +319,8 @@ definition for that predicate in the library: It queries
 `(appearance $)`, which in turn contains the default code for calling
 attention to handled objects.
 
+When an object is pristine, `(appearance $)` also delegates to `(initial appearance $)`. No rules for this predicate are defined by the library—the recommended practice in Dialog is to call attention to pristine objects in the description of their rooms, rather than separating them out. But authors who prefer to give every object its own paragraph may do so by supplying rules for this.
+
 There's one more subtlety to be aware of: Whenever an appearance-rule succeeds,
 the object in question gets _noticed_ by the library. This binds the appropriate
 pronoun (usually “it”) to the object. Therefore, if the appearance-rule doesn't

--- a/manual/modules/lib/pages/libref.adoc
+++ b/manual/modules/lib/pages/libref.adoc
@@ -135,6 +135,7 @@ xref:scenery.adoc#objlocations[`($ has relation $)`] +
 xref:scenery.adoc#descriptions[`(heads $)`] +
 xref:timeprogress.adoc#score[`(increase score by $)`] +
 xref:moving.adoc#light[`(inherently dark $)`] +
+xref:items.adoc#appearance[`(initial appearance $)`] +
 xref:timeprogress.adoc#choicemode[`(initial label $)`] +
 xref:traits.adoc#categorytraits[`(in-seat $)`] +
 xref:actions.adoc#preventperform[`(instead of $)`] +

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -63,6 +63,7 @@
 
 (interface (name $<Obj))
 (interface (descr $<Obj))
+(interface (initial appearance $<Obj))
 (interface (appearance $<Obj))
 (interface (appearance $<Obj $<Rel $<Loc))
 (interface (feel $<Obj))
@@ -4534,6 +4535,9 @@
 
 (appearance $Obj $ $)
 	(appearance $Obj)
+
+(appearance ($Obj is pristine))
+	(initial appearance $Obj)
 
 (appearance (item $Obj))
 	($Obj is handled)

--- a/test/simple/library/new_initial.dg
+++ b/test/simple/library/new_initial.dg
@@ -1,0 +1,9 @@
+(current player #me)
+(#me is #in #room)
+(room #room)
+
+#poster
+(name *) poster
+(* is #in #room)
+(initial appearance *) A poster is tacked to the wall.
+(item *)

--- a/test/simple/library/new_initial.gold
+++ b/test/simple/library/new_initial.gold
@@ -1,0 +1,31 @@
+[Z] Location
+[Z]
+An Interactive Fiction
+An interactive fiction by Anonymous.
+Release 1. Serial number <SERIAL>.
+<COMPILER>. <LIBRARY>
+
+Location
+You are here.
+
+A poster is tacked to the wall.
+
+> take poster
+[Z] Location
+[Z]
+You take the poster.
+
+> drop it
+[Z] Location
+[Z]
+The poster falls to the ground.
+
+> look
+[Z] Location
+[Z]
+Location
+You are here.
+
+You see a poster here.
+
+>

--- a/test/simple/library/new_initial.in
+++ b/test/simple/library/new_initial.in
@@ -1,0 +1,3 @@
+take poster
+drop it
+look


### PR DESCRIPTION
By default, Dialog doesn't provide an equivalent to Inform's "initial appearance", since it wants authors to incorporate objects into the room description instead of giving them their own paragraphs. But there's very little cost to supporting the other style as well, even if it's not recommended. The compiler will simply optimize it out if not used.