### PR TITLE
Include -dev in version numbers on the Z-machine backend

### DIFF
--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -4635,6 +4635,9 @@ void backend_z(
 	zcore[0x1b] = (filesize / packfactor) & 0xff;
 	//zcore[0x2e] = addr_termchar >> 8;
 	//zcore[0x2f] = addr_termchar & 0xff;
+	if(VERSION[5] == '-' && VERSION[6] == 'd') { // -dev version (check hyphen first because VERSION[6] may not exist)
+		zcore[0x38] = '*'; // Indicate with a star in this unused byte
+	}
 	zcore[0x39] = 'D';
 	zcore[0x3a] = 'i';
 	zcore[0x3b] = 'a';

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -4309,7 +4309,8 @@ struct rtroutine rtroutines[] = {
 	},
 	{
 		R_COMPILERVERSION,
-		0,
+		1,
+			// 0: temp
 		(struct zinstr []) {
 			{Z_JG, {VALUE(REG_STATUSBAR), SMALL(1)}, 0, RFALSE},
 			{Z_CALL1N, {ROUTINE(R_SYNC_SPACE)}},
@@ -4317,6 +4318,11 @@ struct rtroutine rtroutines[] = {
 			{Z_CALLVN, {ROUTINE(R_PRINT_N_ZSCII), SMALL(2), SMALL(0x3c)}},
 			{Z_PRINTLIT, {}, 0, 0, "/"},
 			{Z_CALLVN, {ROUTINE(R_PRINT_N_ZSCII), SMALL(2), SMALL(0x3e)}},
+			// Check if -dev version, indicated by a star before the version string
+			{Z_LOADB, {SMALL(0), SMALL(0x38)}, REG_LOCAL+0},
+			{Z_JNE, {VALUE(REG_LOCAL+0), SMALL('*')}, 0, 1},
+			{Z_PRINTLIT, {}, 0, 0, "-dev"},
+			{OP_LABEL(1)},
 			{Z_STORE, {SMALL(REG_SPACE), SMALL(0)}},
 			{Z_RFALSE},
 			{Z_END},

--- a/test/gosling/Makefile
+++ b/test/gosling/Makefile
@@ -8,6 +8,7 @@ gosling.z8: ../../src/dialogc gosling_complete_nostyles.dg
 
 zmachine.out: gosling.z8 gosling.in
 	dfrotz -m -s 1234 gosling.z8 <gosling.in >zmachine.out
+	echo "" >> zmachine.out
 
 zmachine: zmachine.out
 	$(DIFF) zmachine.out zmachine.gold

--- a/test/gosling/zmachine.gold
+++ b/test/gosling/zmachine.gold
@@ -112,7 +112,7 @@ the carpet. Even if the police won't listen, Watson will! So you imagine
 yourself following him, and the world around you changes... Miss Gosling's Last Case
 An interactive mystery by Daniel M. Stelzer.
 Release 3. Serial number ZMACHINE.
-Dialog compiler version 1a/01. Library version 0.46 (modified).
+Dialog compiler version 1a/01-dev. Library version 0.46 (modified).
 
 Sitting room
 The big south-facing windows in this room give it the best light in the house,

--- a/test/impossible/zmachine.gold
+++ b/test/impossible/zmachine.gold
@@ -4,7 +4,7 @@ The Impossible Stairs
 An interactive fiction by Mathbrush.
 Written in Dialog. Authorized sequel to The Impossible Bottle by Linus Åkesson.
 Release 3. Serial number DEBUG.
-Dialog compiler version 1a/01. Library version 1.0.0-dev.
+Dialog compiler version 1a/01-dev. Library version 1.0.0-dev.
 
 What a mess! The hurricane did a real number on the old family home, and to
 think it would happen the week that your dad is moving out!


### PR DESCRIPTION
There's a byte in the header at $38, right before the version string, that currently goes unused. This PR stores `*` there if it's a -dev version of the compiler, and the Z-machine runtime checks for that to add `-dev` to the end of the displayed compiler version.

In other words, this means we can now distinguish between 1a/01 and 1a/01-dev in compiled output.