### PR TITLE
Add support for Unicode translation tables on Z-machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ test/regtest/%.zblorb: src/dialogc test/regtest/%.dg stdlib.dg
 
 test: test/regtest/cloak.zblorb src/dgdebug
 	bin/regtest.py -v --game test/regtest/cloak.zblorb --interpreter dfrotz test/regtest/cloak.regtest
-	make --directory=./test/gosling test
-	make --directory=./test/impossible test
+	make --directory=./test/gosling test clean
+	make --directory=./test/impossible test clean
 	make --directory=./test/simple all
 	bin/test.py doc
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -64,6 +64,10 @@ void usage(char *prgname) {
 	fprintf(stderr, "--long-term -L    Set long-term heap size (default 500 words).\n");
 	fprintf(stderr, "--strip     -s    Strip internal object names.\n");
 	fprintf(stderr, "\n");
+	fprintf(stderr, "Only for z5, z8, or zblorb format:\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "--no-zscii  -Z    Don't use the standard extended ZSCII table.\n");
+	fprintf(stderr, "\n");
 	fprintf(stderr, "Only for zblorb format:\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "--cover     -c    Cover image filename (PNG, max 1200x1200).\n");
@@ -85,6 +89,7 @@ int main(int argc, char **argv) {
 		{"aux", 1, 0, 'A'},
 		{"long-term", 1, 0, 'L'},
 		{"strip", 0, 0, 's'},
+		{"no-zscii", 0, 0, 'Z'},
 		{0, 0, 0, 0}
 	};
 
@@ -99,6 +104,7 @@ int main(int argc, char **argv) {
 	int opt, i;
 	struct program *prg;
 	int aamachine = 0;
+	int preserve_zscii = 1;
 	struct predname *predname;
 	struct predicate *pred;
 	char compiletime_buf[8], reldate_buf[16];
@@ -108,7 +114,7 @@ int main(int argc, char **argv) {
 	comp_init();
 
 	do {
-		opt = getopt_long(argc, argv, "?hVvo:t:r:c:a:H:A:L:s", longopts, 0);
+		opt = getopt_long(argc, argv, "?hVvo:t:r:c:a:H:A:L:sZ", longopts, 0);
 		switch(opt) {
 			case 0:
 			case '?':
@@ -159,6 +165,9 @@ int main(int argc, char **argv) {
 				break;
 			case 's':
 				strip = 1;
+				break;
+			case 'Z':
+				preserve_zscii = 0;
 				break;
 			default:
 				if(opt >= 0) {
@@ -219,8 +228,10 @@ int main(int argc, char **argv) {
 		prg,
 		argc - optind,
 		argv + optind,
-		aamachine? prepare_dictionary_aa : prepare_dictionary_z))
-	{
+		aamachine? prepare_dictionary_aa : (
+			preserve_zscii ? prepare_dictionary_z_preserve : prepare_dictionary_z_replace
+		)
+	)) {
 		exit(1);
 	}
 

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -337,12 +337,12 @@ static int utf8_to_zscii(uint8_t *dest, int ndest, char *src, uint32_t *special,
 			if(i >= n_extended) { // Not found in the extended ZSCII
 				if(for_dictionary) { // Add a new character to the encoding
 					if(n_extended+1 >= EXTENDED_ZSCII_MAX) { // But we can't!
-						report(LVL_ERR, 0, "Tried to add Unicode character U+%04x to the encoding, but all codepoints have already been allocated! Use the TODO command line option to create more space.", uchar);
+						report(LVL_ERR, 0, "Tried to add Unicode character U+%04x to the encoding, but all codepoints have already been allocated! Use the --no-zscii command line option to save space.", uchar);
 						exit(1);
 					}
 					extended_zscii[i] = uchar;
 				//	if(verbose >= 3) { // TODO
-						report(LVL_DEBUG, 0, "Adding Unicode character U+%04x at codepoint %d", uchar, n_extended);
+						report(LVL_DEBUG, 0, "Adding Unicode character U+%04x at codepoint %d", uchar, EXTENDED_ZSCII_BASE+i);
 				//	}
 					dest[outpos++] = EXTENDED_ZSCII_BASE + i;
 					n_extended++;
@@ -4900,6 +4900,7 @@ void backend_z(
 	}
 	report(LVL_DEBUG, 0, "Objects used: %d of %d (%d%%)", prg->nworldobj, 0x1ffe, (prg->nworldobj)*100/0x1ffe);
 	report(LVL_DEBUG, 0, "Dictionary words used: %d of %d (%d%%)", prg->ndictword, 0x1dff, (prg->ndictword)*100/0x1dff);
+	report(LVL_DEBUG, 0, "Extended ZSCII characters used: %d of %d (%d%%)", n_extended * (addr_unicode?1:0), EXTENDED_ZSCII_MAX, n_extended*(addr_unicode?1:0)*100/EXTENDED_ZSCII_MAX);
 	report(LVL_DEBUG, 0, "Addressable memory used: %05d of %d bytes (%d%%)", used_addressable, 64*1024, used_addressable*100/(64*1024));
 	report(LVL_DEBUG, 0, "        Object table:    %5d", used_objects1);
 	report(LVL_DEBUG, 0, "        Object vars:     %5d", used_objects2);

--- a/src/backend_z.h
+++ b/src/backend_z.h
@@ -1,5 +1,6 @@
 
-void prepare_dictionary_z(struct program *prg);
+void prepare_dictionary_z_preserve(struct program *prg);
+void prepare_dictionary_z_replace(struct program *prg);
 
 void backend_z(
 	char *filename,

--- a/test/impossible/Makefile
+++ b/test/impossible/Makefile
@@ -25,6 +25,6 @@ debugger: debugger.out
 test: debugger zmachine
 
 clean:
-	rm -f *.z8 *.out
+	rm -f *.z8 *.out stdlib.dg
 
 .PHONY:		test clean debugger zmachine

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -1,12 +1,12 @@
 all: language library warnings
 
 language: ../../src/dialogc ../../src/dgdebug
-	make --directory=./language all
+	make --directory=./language all clean
 
 library: ../../src/dialogc ../../src/dgdebug
-	make --directory=./library all
+	make --directory=./library all clean
 
 warnings: ../../src/dialogc
-	make --directory=./warnings all
+	make --directory=./warnings all clean
 
 .PHONY:		all library warnings

--- a/test/simple/warnings/libclosures.gold
+++ b/test/simple/warnings/libclosures.gold
@@ -1,2 +1,0 @@
-Warning: Unsupported character U+013a in dictionary word '@¡ħěłĺø'. This word will never be recognized by the parser.
-Warning: Unsupported character U+0111 in dictionary word '@ŵőřľđ!'. This word will never be recognized by the parser.

--- a/test/simple/warnings/libclosures_TODO.gold
+++ b/test/simple/warnings/libclosures_TODO.gold
@@ -1,0 +1,3 @@
+Warning: Unsupported character U+013a in dictionary word '@¡ħěłĺø'. This word will never be recognized by the parser.
+Warning: Unsupported character U+0111 in dictionary word '@ŵőřľđ!'. This word will never be recognized by the parser.
+# This test needs to be fixed now that Dialog can cope with Unicode characters in dictionary words. We'll have to find some other way to handle this...


### PR DESCRIPTION
Previously, Dialog could output Unicode characters on the Z-machine (using a special opcode that prints an arbitrary Unicode character), but couldn't handle them in input (which always uses the ZSCII character set).

This PR makes Dialog add any Unicode characters it encounters in dictionary words to the ZSCII character set. By default, it adds them to the end of the existing ZSCII characters (see [this thread](https://intfiction.org/t/do-any-z-machine-interpreters-not-support-unicode-translation-tables/74912?u=draconis) for rationale). But if you pass the -no-zscii (-Z) command line option, it discards the existing stock completely.

This fixes #48 .