### PR TITLE
Put header extension table in RAM instead of ROM

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
 	comp_init();
 
 	do {
-		opt = getopt_long(argc, argv, "?hVvo:t:r:c:a:H:A:L:sZ", longopts, 0);
+		opt = getopt_long(argc, argv, "?hVvo:t:r:c:a:H:A:L:sU", longopts, 0);
 		switch(opt) {
 			case 0:
 			case '?':


### PR DESCRIPTION
The ZVM Z-machine interpreter (used in Parchment and Lectrote) requires the header extension table to be placed in RAM rather than ROM, and crashes if it isn't. This isn't actually a requirement of the spec, but we should aim to have Dialog files work on as many systems as possible. So this patch moves the header extension table to RAM, while keeping the Unicode translation table in ROM.

I also used the opportunity to clean up some other miscellaneous issues in the Z-machine output and improve the diagnostics by showing how much space is used by the dictionary.