### PR TITLE
Use standard library argument parsing in dgdebug.exe instead of reinventing the wheel

### DIFF
--- a/src/term_winglk.c
+++ b/src/term_winglk.c
@@ -30,15 +30,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 int winglk_startup_code(const char* cmdline) {
 	int i;
 	
+	// There used to be an elaborate block of code here that took the LPSTRING command line provided by Windows and parsed it out into argc and argv
+	// But the parsing was quite basic (just splitting on every run of spaces) and didn't take into account things like quoting and escaping
+	// Since the Windows versions are only expected to be built with MinGW, we instead use MinGW's built-in way of accessing argc and argv directly
+	// But this isn't standard; if you get compilation errors on these lines, try defining __argc and __argv as extern up above; if that doesn't work, look up how to access command-line parameters on your compiler. Most C compilers offer a way now.
 	argc = __argc;
 	argv = __argv;
 	
-#if 1
+#if 0
 	printf("cmdline \"%s\"\n", cmdline);
 	for(i = 0; i < argc; i++) {
 		printf(" %d: \"%s\"\n", i, argv[i]);
 	}
 #endif
+
 	winglk_app_set_name("Dialog Interactive Debugger");
 	winglk_set_about_text("Dialog Interactive Debugger " VERSION " by Linus Akesson");
 	winglk_set_menu_name("&Debug");


### PR DESCRIPTION
From [here](https://intfiction.org/t/dgdebug-exe-bugs/77361/4?u=draconis):

> Dialog programs are designed for a POSIX environment first and foremost, which means they expect their parameters in the standard argc/argv format (and then POSIX getopt is used for further parsing). But Windows doesn’t provide that format; instead, it provides the entire command line as a single string.
> 
> This isn’t a problem for programs executed in the terminal—there, whichever terminal provides POSIX support also handles things like quotes in command lines. But the debugger isn’t a terminal program; it’s a graphical program, using WinGlk for the interface. And this means Dialog has to convert the Windows command line into POSIX argc/argv on its own.
> 
> So that’s where the first bug comes in. It does this in a very rudimentary way: it doesn’t even use strtok, it just manually steps through the string and breaks at each run of spaces. It looks like MinGW specifically provides extra symbols __argc and __argv that do exactly what’s needed here…but it’s hard for me to test this, since I don’t have any machines with Windows on them.

This branch switches to MinGW's non-standard __argc and __argv parameters to see if it works. The Windows code is already distinctly non-portable, so we're not losing much by bringing in this non-standard extension.