### PR TITLE
Add Standard revision check before Z_TRUECOLOR

### DIFF
--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -631,7 +631,7 @@ struct rtroutine rtroutines[] = {
 	},
 	{
 		R_RESET_STYLE,
-		1,
+		2,
 			// 0: temporary variable
 			// 1: temporary variable
 		(struct zinstr []) {


### PR DESCRIPTION
The Z_TRUECOLOR opcode won't exist on interpreters before Standard 1.1, and in particular this can cause iOS Frotz to crash. So, we need to check the Standard revision before calling that opcode.