### PR TITLE
Remove (the single $) and (the full single $)

### DIFF
--- a/manual/modules/lib/pages/libref.adoc
+++ b/manual/modules/lib/pages/libref.adoc
@@ -345,7 +345,6 @@ xref:traits.adoc#linguistictraits[`(That's $)`] +
 xref:traits.adoc#linguistictraits[`(the $)`] +
 xref:traits.adoc#linguistictraits[`(The $)`] +
 xref:traits.adoc#fullnames[`(the full $)`] +
-xref:miscfeat.adoc#thefullsingle[`(the full single $)`] +
 xref:lang:io.adoc#case[`(The full $)`] +
 xref:traits.adoc#linguistictraits[`(the $ is)`] +
 xref:traits.adoc#linguistictraits[`(The $ is)`] +

--- a/manual/modules/lib/pages/miscfeat.adoc
+++ b/manual/modules/lib/pages/miscfeat.adoc
@@ -509,15 +509,11 @@ actions:
 
 Otherwise, it would just ask: Did you want to eat a marble, or the marble?
 
-[#thefullsingle]
-
 Of course, location is not the only property that makes fungible objects
 distinguishable; any dynamic predicate could have that effect. The standard
 library takes care of the location, but it is up to the story author to check
 any other properties that might differ, and to modify the full name of the
-object as appropriate. When this happens, you should not override
-`(the full $)` directly, but the variant `(the full single $)` that is used
-during disambiguation (for reasons of optimization). Thus:
+object as appropriate. Thus:
 
 [source]
 ----
@@ -538,7 +534,7 @@ during disambiguation (for reasons of optimization). Thus:
 		($A is closed) ($B is closed)
 	}
 
-(the full single (box $Obj))
+(the full (box $Obj))
 	($Obj is $Rel $Loc)
 	the (open or closed $Obj) box (name $Rel) (the full $Loc)
 
@@ -552,7 +548,7 @@ during disambiguation (for reasons of optimization). Thus:
 	box (name $Rel) (the full $Loc)
 
 %% No need for '(clarify location of (box $))', since we override
-%% '(the full single $)' and '(a full $)' directly.
+%% '(the full $)' and '(a full $)' directly.
 ----
 
 

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -189,7 +189,7 @@
 (reverse-name #under)	out from under
 (reverse-name #behind)	out from behind
 
-(the single (relation $Rel))	(name $Rel)
+(the (relation $Rel))	(name $Rel)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Directions
@@ -425,7 +425,7 @@
 		($Obj = $Point)
 	(endif)
 
-(the single (current room $))	this location
+(the (current room $))	this location
 
 (name (door $))		door
 
@@ -4131,14 +4131,8 @@
 (it (nonempty $List) is)	they're
 (them (nonempty $List))		them
 
-(the full (object $Obj))
-	(the full single $Obj)
 (the full $Obj)
 	(the $Obj)
-	(add location information for $Obj)
-%% This is effectively the same as (the full $) for individual objects, but doesn't call (listing...) in any circumstance. Dialog's optimizer struggles when a codepath leads from a (collect words) or (from words) to a closure query, even if that codepath is never executed, so this circumvents that issue.
-(the full single $Obj)
-	(the single $Obj)
 	(add location information for $Obj)
 
 (a full $Obj)
@@ -4164,7 +4158,7 @@
 			(else)
 				that's
 			(endif)
-			(name $Rel) (the full single $Loc)
+			(name $Rel) (the full $Loc)
 		(endif)
 	(endif)
 
@@ -4188,7 +4182,7 @@
 		You
 	(endif)
 
-(the single $Obj)		(current player $Obj) yourself
+(the $Obj)		(current player $Obj) yourself
 (The $Obj)		(current player $Obj) You
 (it $Obj)		(current player $Obj) you
 (them $Obj)		(current player $Obj) you
@@ -4207,10 +4201,10 @@
 (That's $Obj)		(current player $Obj) You're
 
 (a (proper $Obj))	(maybe link $Obj)
-(the single (proper $Obj))	(name $Obj)
+(the (proper $Obj))	(name $Obj)
 
 (a (your $Obj))		your (maybe link $Obj)
-(the single (your $Obj))	your (name $Obj)
+(the (your $Obj))	your (name $Obj)
 
 (a (singleton $Obj))	(maybe link $Obj {(the $_)})
 
@@ -4258,7 +4252,7 @@
 (it (gender-neutral $) es)
 
 (a $Obj)		a (maybe link $Obj)
-(the single $Obj)		the (name $Obj)
+(the $Obj)		the (name $Obj)
 (it $)			it
 (them $)		it
 (itself $)		itself
@@ -4280,8 +4274,6 @@
 
 (doesn't $Obj)		(does $Obj) (no space) n't
 (it $Obj doesn't)	(it $Obj does) (no space) n't
-
-(the (object $Obj))	(the single $Obj) %% We break (the single $) out from (the $) to improve closure optimization
 
 (name $)
 
@@ -6026,7 +6018,7 @@
 			~(relation $Obj)
 			(words $Words sufficiently specify $Obj)
 		(from words)
-			(the full single $Obj)
+			(the full $Obj)
 		(matching all of $Words)
 		(recover implicit action $Template $Obj into $A)
 	(into $Candidates)

--- a/test/simple/language/Makefile
+++ b/test/simple/language/Makefile
@@ -20,7 +20,7 @@ explicit: $(explicit)
 ## Call the original dialogc and dgdebug from $PATH here, not our modified ones from $(BASEPATH)
 	touch -a $*.gold
 ## First, make the Z-machine version
-	dialogc $*.dg dummylib.dglib -t z5 -o $*.z5
+	dialogc $*.dg dummylib.dglib --no-warn-not-topic -t z5 -o $*.z5
 	$(BASEPATH)/bin/echoing.py dfrotz -w 80 -s 1234 -h 999 -mq $*.z5 <$*.z.in >$*.z.out
 ## For consistency, strip final spaces - those are mostly inserted by the debugger, but can happen in some cases, and this makes the output align
 	perl -i -pe 's/ $$//' $*.z.out
@@ -38,10 +38,10 @@ explicit: $(explicit)
 origin: $(origin)
 
 %.z5: $(BASEPATH)/src/dialogc %.dg
-	$(BASEPATH)/src/dialogc $*.dg dummylib.dglib -t z5 -o $*.z5
+	$(BASEPATH)/src/dialogc $*.dg dummylib.dglib --no-warn-not-topic -t z5 -o $*.z5
 
 %.aastory: $(BASEPATH)/src/dialogc %.dg
-	$(BASEPATH)/src/dialogc $*.dg dummylib.dglib -t aa -o $*.aastory
+	$(BASEPATH)/src/dialogc $*.dg dummylib.dglib --no-warn-not-topic -t aa -o $*.aastory
 
 %.debug: %.dg
 	cat $*.dg dummylib.dglib > $*.debug
@@ -70,7 +70,7 @@ origin: $(origin)
 	touch $*.aa.out
 
 %.d.out: $(BASEPATH)/src/dgdebug %.debug %.d.in
-	$(BASEPATH)/src/dgdebug -qD -w 80 -s 1234 $*.debug <$*.d.in >$*.d.out
+	$(BASEPATH)/src/dgdebug -qD -w 80 -s 1234 $*.debug --no-warn-not-topic <$*.d.in >$*.d.out
 ## Remove trailing spaces from lines for easier diffing
 	perl -i -pe 's/ $$//' $*.d.out
 

--- a/test/simple/library/man_11b.dg
+++ b/test/simple/library/man_11b.dg
@@ -47,7 +47,7 @@
 		($A is closed) ($B is closed)
 	}
 
-(the full single (box $Obj))
+(the full (box $Obj))
 	($Obj is $Rel $Loc)
 	the (open or closed $Obj) box (name $Rel) (the full $Loc)
 

--- a/test/simple/library/man_11c.dg
+++ b/test/simple/library/man_11c.dg
@@ -47,7 +47,7 @@
 		($A is closed) ($B is closed)
 	}
 
-(the full single (box $Obj))
+(the full (box $Obj))
 	($Obj is $Rel $Loc)
 	the (open or closed $Obj) box (name $Rel) (the full $Loc)
 


### PR DESCRIPTION
Previously, we added `(the single $)` and `(the full single $)` to avoid an optimization issue. But that optimization issue has become less relevant due to other fixes. This PR removes them again to make the library more elegant.

#121 