### PR TITLE
Report usage of Z-machine registers

### DIFF
--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -4473,6 +4473,11 @@ void backend_z(
 	nglobal = (REG_X - 0x10) + max_temp;
 	user_global_base = nglobal;
 	nglobal += next_user_global;
+	
+	if(nglobal > 240) {
+		report(LVL_ERR, 0, "%d registers are assigned (%d internal, %d temp, %d global), but the Z-machine only supports 240.", nglobal, REG_X-0x10, max_temp, next_user_global);
+		exit(1);
+	}
 
 	resolve_rnum(R_ENTRY);
 	for(i = 1; i < 64; i++) {
@@ -4968,7 +4973,8 @@ void backend_z(
 	report(LVL_DEBUG, 0, "Heap: %d words", heapsize);
 	report(LVL_DEBUG, 0, "Auxiliary heap: %d words", auxsize);
 	report(LVL_DEBUG, 0, "Long-term heap: %d words", ltssize);
-	report(LVL_DEBUG, 0, "Registers used: %d of %d* (%d%%)", nglobal, 240, nglobal*100/240);
+	report(LVL_DEBUG, 0, "Registers used: %d of %d (%d%%)", nglobal, 240, nglobal*100/240);
+	report(LVL_DEBUG, 0, "                %d internal, %d temp, %d global", REG_X-0x10, max_temp, next_user_global);
 	report(LVL_DEBUG, 0, "Properties used: %d of %d (%d%%)", next_free_prop-1, 63, (next_free_prop-1)*100/63);
 	report(LVL_DEBUG, 0, "Dynamic flags used: %d of %d (%d%%)", used_attributes, NZOBJFLAG, used_attributes*100/NZOBJFLAG);
 	if(next_flag > NZOBJFLAG) {


### PR DESCRIPTION
All versions of the Z-machine have 240 registers that can be accessed from anywhere in the program. Dialog uses these for various purposes, but previously didn't check if they ran out.

Now it does. It also reports how many are used for various purposes if compiling with `-vv`.

Miss Gosling:
```
Debug: Registers used: 113 of 240 (47%)
Debug:                 61 internal, 19 temp, 33 global
```

Impossible Stairs:
```
Debug: Registers used: 122 of 240 (50%)
Debug:                 61 internal, 32 temp, 29 global
```

So hopefully nobody is running out any time soon!