### PR TITLE
Add ability to force height in debugger

### DIFF
--- a/manual/modules/ROOT/pages/software.adoc
+++ b/manual/modules/ROOT/pages/software.adoc
@@ -300,6 +300,14 @@ Shows the current state of all dynamic predicates (global flags, global variable
 per-object flags, and per-object variables). For global flags, it also shows
 whether they’ve been changed via `(now)`.
 
+@more::
+
+Enables \[more\] prompts after each page of output.
+
+@nomore::
+
+Disables \[more\] prompts, so many pages of output can appear at once.
+
 You can get a full list of debugging commands by typing `@help` at the
 prompt. These commands can be abbreviated as long as the abbreviation is unique;
 `@h` works for `@help`, for instance.

--- a/readme.txt
+++ b/readme.txt
@@ -121,13 +121,20 @@ Release notes:
 		Debugger: --no-header option suppresses version information, for
 		the same reason.
 		
+		Debugger: --height option allows forcing a terminal height; -1
+		means infinite. New @more and @nomore debugging commands can
+		change this at run-time.
+		
 		Debugger: --tag-lines option explicitly marks requests for key
 		and line input, for the same reason.
 		
 		Debugger: now tags fixed-width text with an ANSI escape sequence.
-
+		
 		Debugger: terminal width will now be measured immediately after
 		launching.
+		
+		Debugger: --unit-test option is equivalent to --no-warn-not-topic
+		--quit --height=-1, but much shorter to type.
 		
 		Library: new commands SUPERBRIEF, BRIEF, VERBOSE, and SUPERVERBOSE
 		change how rooms are described while going. The default behavior

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1315,6 +1315,7 @@ void usage(char *prgname) {
 	fprintf(stderr, "--numbered  -N      Show call depth with numbers during tracing.\n");
 	fprintf(stderr, "--tag-lines -T      Prepend output with \"  \", input with \"> \" or \") \".\n");
 	fprintf(stderr, "--no-header         Don't show version information at startup.\n");
+	fprintf(stderr, "--unit-test -u      Same as --no-warn-not-topic --quit --height=-1.\n");
 }
 
 extern int topic_warning_level; // Defined in frontend.c
@@ -1339,6 +1340,7 @@ int debugger(int argc, char **argv) {
 		{"no-warn-not-topic", 0, &topic_warning_level, 2},
 		{"tag-lines", 0, 0, 'T'},
 		{"no-header", 0, &suppress_header, 1},
+		{"unit-test", 0, 0, 'u'},
 		{0, 0, 0, 0}
 	};
 
@@ -1362,7 +1364,7 @@ int debugger(int argc, char **argv) {
 	dbg.timestamps = calloc(argc, sizeof(struct timespec));
 
 	do {
-		opt = getopt_long(argc, argv, "?hVvtnqw:H:s:W:LDNT", longopts, 0);
+		opt = getopt_long(argc, argv, "?hVvtnqw:H:s:W:LDNTu", longopts, 0);
 		switch(opt) {
 			case 0:
 				break; // Changed DMS to allow long-only options
@@ -1408,6 +1410,11 @@ int debugger(int argc, char **argv) {
 				break;
 			case 'T':
 				io_tag_lines = 1;
+				break;
+			case 'u': // --no-warn-not-topic --quit --height=-1
+				topic_warning_level = 2;
+				quitopt = 1;
+				force_height = -1;
 				break;
 			default:
 				if(opt >= 0) {

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -44,6 +44,7 @@ struct debugger {
 };
 
 static int force_width;
+static int force_height;
 extern int use_numbered_levels; // Defined in eval.c
 extern int return_value; // Defined in eval.c
 int io_tag_lines = 0; // Used in term_tty.c, output.c
@@ -1307,6 +1308,7 @@ void usage(char *prgname) {
 	fprintf(stderr, "--quit      -q      Quit the debugger when the program terminates.\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "--width     -w      Specify output width, in characters (-1 = infinite).\n");
+	fprintf(stderr, "--height    -H      Specify output height, in lines (-1 = infinite).\n");
 	fprintf(stderr, "--seed      -s      Specify random seed.\n");
 	fprintf(stderr, "--no-links  -L      Don't show hyperlinks in the output.\n");
 	fprintf(stderr, "--dfquirks  -D      Activate the dumbfrotz-compatible quirks mode.\n");
@@ -1327,6 +1329,7 @@ int debugger(int argc, char **argv) {
 		{"no-entry", 0, 0, 'n'},
 		{"quit", 0, 0, 'q'},
 		{"width", 1, 0, 'w'},
+		{"height", 1, 0, 'H'},
 		{"seed", 1, 0, 's'},
 		{"no-links", 0, 0, 'L'},
 		{"dfquirks", 0, 0, 'D'},
@@ -1359,7 +1362,7 @@ int debugger(int argc, char **argv) {
 	dbg.timestamps = calloc(argc, sizeof(struct timespec));
 
 	do {
-		opt = getopt_long(argc, argv, "?hVvtnqw:s:W:LDNT", longopts, 0);
+		opt = getopt_long(argc, argv, "?hVvtnqw:H:s:W:LDNT", longopts, 0);
 		switch(opt) {
 			case 0:
 				break; // Changed DMS to allow long-only options
@@ -1384,6 +1387,9 @@ int debugger(int argc, char **argv) {
 				break;
 			case 'w':
 				force_width = strtol(optarg, 0, 10);
+				break;
+			case 'H':
+				force_height = strtol(optarg, 0, 10);
 				break;
 			case 's':
 				dbg.randomseed = strtol(optarg, 0, 10);
@@ -1416,7 +1422,7 @@ int debugger(int argc, char **argv) {
 	dbg.filenames = argv + optind;
 
 	term_init(eval_interrupt);
-	o_reset(force_width, dfrotz_quirks);
+	o_reset(force_width, force_height, dfrotz_quirks);
 	comp_init();
 
 	if(io_tag_lines) o_line(); // Avoid special cases
@@ -1514,7 +1520,7 @@ int debugger(int argc, char **argv) {
 			break;
 		case ESTATUS_RESTART:
 			return_value = 0;
-			o_reset(force_width, dfrotz_quirks);
+			o_reset(force_width, force_height, dfrotz_quirks);
 			if(!restart(&dbg)) {
 				running = 0;
 				break;
@@ -1538,7 +1544,7 @@ int debugger(int argc, char **argv) {
 			o_print_str("entry point)");
 			o_end_box();
 			eval_reinitialize(&dbg.es);
-			o_reset(force_width, dfrotz_quirks);
+			o_reset(force_width, force_height, dfrotz_quirks);
 			v = (value_t) {VAL_NUM, dbg.status};
 			dbg.status = eval_program_entry(&dbg.es, find_builtin(dbg.prg, BI_ERROR_ENTRY), &v);
 			break;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -47,7 +47,8 @@ static int force_width;
 static int force_height;
 extern int use_numbered_levels; // Defined in eval.c
 extern int return_value; // Defined in eval.c
-int io_tag_lines = 0; // Used in term_tty.c, output.c
+int io_tag_lines; // Used in term_tty.c, output.c
+static int dfrotz_quirks;
 
 char *STOPCHARS; // Declared in common.h, defined here and in backend.c
 
@@ -1144,6 +1145,16 @@ static void cmd_restore(struct debugger *dbg) {
 	}
 }
 
+static void cmd_more(struct debugger *dbg) {
+	force_height = 0;
+	o_reset(force_width, force_height, dfrotz_quirks);
+}
+
+static void cmd_nomore(struct debugger *dbg) {
+	force_height = -1;
+	o_reset(force_width, force_height, dfrotz_quirks);
+}
+
 struct debugcmd {
 	char	*name;
 	void	(*invoke)(struct debugger *dbg);
@@ -1153,6 +1164,8 @@ struct debugcmd {
 	{"dynamic",	cmd_dyn,	"Show the current state of all dynamic predicates."},
 	{"g",		cmd_again,	"Same as @again."},
 	{"help",	cmd_help,	"Display this help text."},
+	{"more",	cmd_more,	"Enable [more] prompts for long output, if possible."},
+	{"nomore",	cmd_nomore,	"Disable [more] prompts for long output, if possible."},
 	{"quit",	cmd_quit,	"Quit the debugger."},
 	{"replay",	cmd_replay,	"Restart, then replay the accumulated game input."},
 	{"restore",	cmd_restore,	"Restart and read game input from a file."},
@@ -1355,7 +1368,7 @@ int debugger(int argc, char **argv) {
 	struct predname *predname;
 	int initial_trace = 0, no_entry = 0, quitopt = 0;
 	struct timeval tv;
-	int dfrotz_quirks = 0, hide_links = 0;
+	int hide_links = 0;
 	char numbuf[8], chbuf[8];
 	struct word *w;
 	uint16_t unibuf[2];

--- a/src/dumb_output.c
+++ b/src/dumb_output.c
@@ -34,7 +34,7 @@ void o_progress_bar(int a, int b)		{ bail_out(); }
 void o_clear(int all)				{ bail_out(); }
 void o_post_input(int external_lf)		{ bail_out(); }
 
-void o_reset(int force_w, int quirks) {
+void o_reset(int force_w, int force_h, int quirks) {
 	force_width = force_w;
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -52,6 +52,7 @@ static int column;
 static int width = 79, height = 0;
 static int dfrotz_quirks;
 static int force_width;
+static int force_height;
 static int nowrap;
 
 extern int io_tag_lines; // debugger.c
@@ -61,12 +62,14 @@ extern int io_tag_lines; // debugger.c
 static void syncwrap();
 
 static void update_size() {
-	int w;
+	int w, h;
 
-	term_get_size(&w, &height);
+	term_get_size(&w, &h, force_width, force_height);
 	if(force_width) w = force_width;
+	if(force_height) h = force_height;
 	if(w < width) syncwrap();
 	width = w;
+	height = h;
 	wrapbuf = realloc(wrapbuf, (width + 1) * sizeof(uint16_t));
 }
 
@@ -428,13 +431,15 @@ void o_post_input(int external_lf) {
 	term_effectstyle(wrapstyle);
 }
 
-void o_reset(int force_w, int quirks) {
+void o_reset(int force_w, int force_h, int quirks) {
 	force_width = force_w;
 	if(force_width < 0) { // Negative means disable wrapping
 		force_width = 79; // Needed to size the buffer
 		nowrap = 1;
 	}
 	if(force_width) width = force_width;
+	force_height = force_h;
+	if(force_height) height = force_height;
 	update_size();
 	space = SP_DONELINE + (quirks? 999 : 0);
 	wrapbuf = realloc(wrapbuf, (width + 1) * sizeof(uint16_t));

--- a/src/output.h
+++ b/src/output.h
@@ -20,7 +20,7 @@ void o_end_self_link();
 void o_progress_bar(int position, int total);
 void o_clear(int all);
 void o_post_input(int external_lf);
-void o_reset(int force_width, int quirks);
+void o_reset(int force_width, int force_height, int quirks);
 void o_leave_all(void);
 void o_cleanup(void);
 int o_get_width(void);

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -32,6 +32,7 @@ static term_int_callback_t term_int_callback;
 static int unread_lines;
 static int termstyle;
 static int term_height;
+static int force_height;
 static int did_tcsetattr;
 static struct termios tio_orig;
 static uint16_t last_filename[256];
@@ -80,17 +81,19 @@ void morefunc() {
 	}
 }
 
-void term_get_size(int *width, int *height) {
+void term_get_size(int *width, int *height, int force_w, int force_h) {
 	struct winsize ws;
-
+	force_height = force_h;
+	
 	if(!ioctl(0, TIOCGWINSZ, &ws)) {
 		*width = (ws.ws_col >= 1)? ws.ws_col - 1 : 0;
 		if(io_tag_lines) *width -= 2; // For the tags
 		*height = ws.ws_row;
-		term_height = ws.ws_row;
+		term_height = force_height ? force_height : ws.ws_row;
 	} else {
 		*width = 79;
 		*height = 0;
+		term_height = force_height ? force_height : ws.ws_row;
 	}
 }
 

--- a/src/term_winglk.c
+++ b/src/term_winglk.c
@@ -131,7 +131,7 @@ int term_getkey(const char *prompt) {
 	}
 }
 
-void term_get_size(int *width, int *height) {
+void term_get_size(int *width, int *height, int force_w, int force_h) {
 	*width = 79;
 	*height = 0;
 }

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -23,5 +23,5 @@ void term_effectstyle(int style);
 void term_clear(int all);
 
 int term_is_interactive(void);
-void term_get_size(int *width, int *height);
+void term_get_size(int *width, int *height, int force_w, int force_h);
 int term_handles_wrapping(void);

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,6 +1,6 @@
 all: test 
 
-DEBUG=../../src/dgdebug -q --no-warn-not-topic
+DEBUG=../../src/dgdebug -u
 STDLIB=../../unit.dg ../../stdlib.dg
 
 test: time utils pass-1 fail-1


### PR DESCRIPTION
New `--height` option acts like `--width` but for terminal height. Useful for disabling `[more]` prompts.