### PR TITLE
Add color support to the debugger

### DIFF
--- a/manual/modules/lang/pages/io.adoc
+++ b/manual/modules/lang/pages/io.adoc
@@ -92,7 +92,7 @@ Supported values are `normal`, `bold`, and `inherit`.
 font-family::
 The value is checked for the presence or absence of the keyword `monospace`, or for the exact text `inherit`.
 
-font-decoration::
+text-decoration::
 The value is checked for the presence or absence of the keyword `reverse`, or for the exact text `inherit`. A value containing `reverse` instructs the interpreter to reverse the foreground and background colors, whatever they might be; this is not standard CSS, but is more widely supported on retro hardware than setting the colors directly.
 
 display::

--- a/manual/modules/lang/pages/io.adoc
+++ b/manual/modules/lang/pages/io.adoc
@@ -96,7 +96,7 @@ text-decoration::
 The value is checked for the presence or absence of the keyword `reverse`, or for the exact text `inherit`. A value containing `reverse` instructs the interpreter to reverse the foreground and background colors, whatever they might be; this is not standard CSS, but is more widely supported on retro hardware than setting the colors directly.
 
 display::
-Supported values are `none` and `inherit`. Spans marked with `display: none` are not displayed in any way, but their contents _will_ appear in the xref:builtins.adoc#system[transcript]. If any important information is conveyed in a status area, this can be used to ensure it's also recorded in the transcript.
+Supported values are `none` and `inherit`. Content marked with `display: none` is not displayed in any way, but _will_ appear in the xref:builtins.adoc#system[transcript]. If any important information is conveyed in a status area, this can be used to ensure it's also recorded in the transcript.
 
 CAUTION: Using `display:none` on spans (rather than divs) is not recommended, because any spacing around them will still be visible. This is true for all backends.
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,9 @@ Release notes:
 		Backend: Å-machine backend now reports when non-ASCII characters
 		are added to the character set.
 		
+		Debugger: now supports color and background-color style class
+		properties in a very minimal way.
+		
 		Debugger: --width -1 disables word wrapping, for piping to other
 		programs.
 		

--- a/src/dumb_output.c
+++ b/src/dumb_output.c
@@ -22,6 +22,7 @@ void o_nbsp()					{ bail_out(); }
 void o_nospace()				{ bail_out(); }
 void o_sync()					{ bail_out(); }
 void o_set_style(int style)			{ bail_out(); }
+void o_set_style_colors(int style, int fg, int bg)	{ bail_out(); }
 void o_set_upper()				{ bail_out(); }
 void o_print_word(const char *utf8)		{ bail_out(); }
 void o_print_opaque_word(const char *utf8)	{ bail_out(); }

--- a/src/eval.c
+++ b/src/eval.c
@@ -28,7 +28,7 @@ static int eval_color(int16_t rawcolor, int inheritfrom) {
 	if(rawcolor >= 0) return OCOLOR_INITIAL;
 	if(rawcolor == COLOR_INHERIT) return inheritfrom;
 	if(rawcolor == COLOR_INITIAL) return OCOLOR_INITIAL;
-	return (-1) - rawcolor;
+	return (-3) - rawcolor;
 }
 
 value_t eval_deref(value_t v, struct eval_state *es) {
@@ -1450,7 +1450,7 @@ static int eval_run(struct eval_state *es) {
 					es->divstyle &= ~(es->program->boxclasses[ci->oper[0].value].unstyle);
 					es->divstyle |=  (es->program->boxclasses[ci->oper[0].value].style & 0xff);
 					es->divfg = eval_color(es->program->boxclasses[ci->oper[0].value].color, es->divfg);
-					es->divbg = eval_color(es->program->boxclasses[ci->oper[0].value].color, es->divbg);
+					es->divbg = eval_color(es->program->boxclasses[ci->oper[0].value].bgcolor, es->divbg);
 					o_set_style(STYLE_ROMAN);
 					o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 				}
@@ -1793,9 +1793,11 @@ static int eval_run(struct eval_state *es) {
 				v = es->auxstack[--es->aux]; // Pull style
 				assert(v.tag == VAL_NUM);
 				es->divstyle = v.value;
+				assert(es->aux);
 				v = es->auxstack[--es->aux]; // Pull fg
 				assert(v.tag == VAL_NUM);
 				es->divfg = v.value;
+				assert(es->aux);
 				v = es->auxstack[--es->aux]; // Pull bg
 				assert(v.tag == VAL_NUM);
 				es->divbg = v.value;

--- a/src/eval.c
+++ b/src/eval.c
@@ -23,6 +23,14 @@ void eval_interrupt() {
 	interrupted = 1;
 }
 
+// Converts COLOR_ (Z-machine) to OCOLOR_ (ANSI escapes)
+static int eval_color(int16_t rawcolor, int inheritfrom) {
+	if(rawcolor >= 0) return OCOLOR_INITIAL;
+	if(rawcolor == COLOR_INHERIT) return inheritfrom;
+	if(rawcolor == COLOR_INITIAL) return OCOLOR_INITIAL;
+	return (-1) - rawcolor;
+}
+
 value_t eval_deref(value_t v, struct eval_state *es) {
 	int pos;
 
@@ -503,7 +511,9 @@ static int eval_pop_undo(struct eval_state *es) {
 		if(es->program->boxclasses[es->divstack[es->divsp - 1]].style) {
 			es->divstyle = es->program->boxclasses[es->divstack[es->divsp - 1]].style & 0xff;
 		}
-		o_set_style(es->divstyle);
+		es->divfg = eval_color(es->program->boxclasses[es->divstack[es->divsp-1]].color, OCOLOR_INITIAL);
+		es->divbg = eval_color(es->program->boxclasses[es->divstack[es->divsp-1]].bgcolor, OCOLOR_INITIAL);
+		o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 	}
 	// Note: this does NOT evaluate the whole div stack for the purpose of `inherit` properties
 	// Undoing with a non-empty div stack is rare, though, so it's generally fine
@@ -1421,7 +1431,11 @@ static int eval_run(struct eval_state *es) {
 					pred_release(pp.pred);
 					return ESTATUS_ERR_IO;
 				} else {
-					if(!push_aux(es, (value_t) {VAL_NUM, es->divstyle})) {
+					if(
+						!push_aux(es, (value_t) {VAL_NUM, es->divbg}) || // Push bg
+						!push_aux(es, (value_t) {VAL_NUM, es->divfg}) || // Push fg
+						!push_aux(es, (value_t) {VAL_NUM, es->divstyle}) // Push style
+					) {
 						pred_release(pp.pred);
 						return ESTATUS_ERR_AUX;
 					}
@@ -1435,8 +1449,10 @@ static int eval_run(struct eval_state *es) {
 					}
 					es->divstyle &= ~(es->program->boxclasses[ci->oper[0].value].unstyle);
 					es->divstyle |=  (es->program->boxclasses[ci->oper[0].value].style & 0xff);
+					es->divfg = eval_color(es->program->boxclasses[ci->oper[0].value].color, es->divfg);
+					es->divbg = eval_color(es->program->boxclasses[ci->oper[0].value].color, es->divbg);
 					o_set_style(STYLE_ROMAN);
-					o_set_style(es->divstyle);
+					o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 				}
 			}
 			break;
@@ -1757,7 +1773,7 @@ static int eval_run(struct eval_state *es) {
 					o_par_n(es->program->boxclasses[ci->oper[0].value].marginbottom);
 				}
 				o_set_style(STYLE_ROMAN);
-				o_set_style(es->divstyle);
+				o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 			}
 			break;
 		case I_END_BOX:
@@ -1774,11 +1790,17 @@ static int eval_run(struct eval_state *es) {
 					o_par_n(es->program->boxclasses[ci->oper[0].value].marginbottom);
 				}
 				assert(es->aux);
-				v = es->auxstack[--es->aux];
+				v = es->auxstack[--es->aux]; // Pull style
 				assert(v.tag == VAL_NUM);
 				es->divstyle = v.value;
+				v = es->auxstack[--es->aux]; // Pull fg
+				assert(v.tag == VAL_NUM);
+				es->divfg = v.value;
+				v = es->auxstack[--es->aux]; // Pull bg
+				assert(v.tag == VAL_NUM);
+				es->divbg = v.value;
 				o_set_style(STYLE_ROMAN);
-				o_set_style(es->divstyle);
+				o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 			}
 			break;
 		case I_END_LINK:
@@ -3016,6 +3038,10 @@ void eval_reinitialize(struct eval_state *es) {
 	es->inStatus = 0;
 	es->nSpan = 0;
 	es->nLink = 0;
+	
+	es->divstyle = STYLE_ROMAN;
+	es->divfg = OCOLOR_INITIAL;
+	es->divbg = OCOLOR_INITIAL;
 }
 
 int eval_initial(struct eval_state *es, struct predname *predname, value_t *args) {

--- a/src/eval.h
+++ b/src/eval.h
@@ -101,7 +101,9 @@ struct eval_state {
 
 	uint8_t			forwords;
 	uint8_t			trace;
-	uint8_t			divstyle;
+	uint8_t			divstyle; // Style (italic etc)
+	uint8_t			divfg; // Foreground ocolor
+	uint8_t			divbg; // Background ocolor
 	uint8_t			divsp;
 	uint8_t			errorflag;	// set on e.g. heap overflow
 	uint8_t			hide_links;

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2968,11 +2968,14 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 					} else if(strcmp(param, "inherit")) { // Something that's not monospace was specified, and it was *not* inherit
 						bc->unstyle |= STYLE_FIXED;
 					}
-				} else if(1 == sscanf(str, "font-decoration : %s", param)) {
+				} else if(1 == sscanf(str, "text-decoration : %s", param)) {
 					if(strstr(str, "reverse")) { // This is not a standard CSS property, but there is no standard CSS property for reverse video, and unrecognized property values are explicitly not an error in CSS
 						bc->style |= STYLE_REVERSE;
 					} else if(strcmp(param, "inherit")) { // As above, something that's not reverse was specified, and it's *not* inherit
 						bc->unstyle |= STYLE_REVERSE;
+					}
+					if(strstr(str, "debug")) { // It's sometimes useful to set the STYLE_DEBUG flag manually. This is deliberately not documented.
+						bc->style |= STYLE_DEBUG;
 					}
 				} else if(1 == sscanf(str, "display : %s", param)) {
 					if(!strcmp(param, "none")) { // display:none indicates that a span/div should be sent to the transcript but not to the screen, like the quote boxes in Trinity
@@ -3017,6 +3020,9 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 				(bc->unstyle & STYLE_FIXED)? "no" : "inherit");
 			if(bc->style & STYLE_INVISIBLE) {
 				printf("\tUndisplayed\n");
+			}
+			if(bc->style & STYLE_DEBUG) {
+				printf("\tDebug\n");
 			}
 			if(bc->color < 0) { // Print negatives in decimal
 				printf("\tColor:\t%d\n", bc->color);

--- a/src/output.c
+++ b/src/output.c
@@ -35,6 +35,8 @@ enum {
 struct boxstate {
 	uint8_t		boxclass;
 	uint8_t		style;
+	uint8_t		fgcolor; // 0-7 colors, 8 OCOLOR_INHERIT, 9 OCOLOR_INITIAL
+	uint8_t		bgcolor;
 	uint8_t		upper;
 	uint8_t		visible;
 	uint8_t		wrap;
@@ -48,6 +50,7 @@ static uint16_t *wrapbuf;
 static int delayed_spaces;
 static int wrappos;
 static int wrapstyle;
+static int wrapfg = OCOLOR_INITIAL, wrapbg = OCOLOR_INITIAL;
 static int column;
 static int width = 79, height = 0;
 static int dfrotz_quirks;
@@ -92,6 +95,7 @@ static void syncwrap() {
 	if(wrapstyle) {
 		term_effectstyle(wrapstyle);
 	}
+	term_colors(wrapfg, wrapbg);
 	unicode_to_utf8_n(utf8, (wrappos + 1) * 3, wrapbuf, wrappos);
 	term_sendbytes(utf8, strlen((char *) utf8));
 	column += wrappos;
@@ -148,9 +152,11 @@ static void sendnbsp() { // Send a space without wrapping
 	wrapbuf[wrappos++] = ' ';
 }
 
-static void sendstyle(int style) {
+static void sendstyle(int style, int fg, int bg) {
 	if(wrappos) syncwrap();
 	wrapstyle = style;
+	wrapfg = fg;
+	wrapbg = bg;
 }
 
 // These routines correspond to what the runtime layer is doing.
@@ -188,6 +194,8 @@ void o_begin_box(char *boxclass) {
 
 	boxstack[boxsp].visible = boxstack[boxsp - 1].visible;
 	boxstack[boxsp].style = 0;
+	boxstack[boxsp].fgcolor = OCOLOR_INITIAL;
+	boxstack[boxsp].bgcolor = OCOLOR_INITIAL;
 	boxstack[boxsp].upper = 0;
 	boxstack[boxsp].wrap = !(term_handles_wrapping() || nowrap);
 	if(!strcmp(boxclass, "span")) {
@@ -218,7 +226,7 @@ void o_begin_box(char *boxclass) {
 			boxstack[boxsp].boxclass = CLA_UNKNOWN;
 		}
 	}
-	sendstyle(boxstack[boxsp].style);
+	sendstyle(boxstack[boxsp].style, boxstack[boxsp].fgcolor, boxstack[boxsp].bgcolor);
 }
 
 void o_end_box() {
@@ -227,7 +235,7 @@ void o_end_box() {
 			o_line();
 		}
 		boxsp--;
-		sendstyle(boxstack[boxsp].style);
+		sendstyle(boxstack[boxsp].style, boxstack[boxsp].fgcolor, boxstack[boxsp].bgcolor);
 	} else {
 		o_line();
 	}
@@ -276,28 +284,33 @@ void o_sync() {
 	}
 	syncwrap();
 	term_effectstyle(wrapstyle);
+	term_colors(wrapfg, wrapbg);
 }
 
-void o_set_style(int style) {
+void o_set_style_colors(int style, int fg, int bg) {
 	if(style & STYLE_INVISIBLE){ // Invisibility is handled at this level instead of in sendstyle
 		boxstack[boxsp].visible = 0;
 	}
 	if(!boxstack[boxsp].visible) return;
 
 	if(style) {
-		// https://github.com/Dialog-IF/dialog/issues/189
-	/*	if(space == SP_AUTO || space == SP_SPACE) {
-			sendspace();
-			space = SP_DONESPACE;
-		} else if(space == SP_NBSP) {
-			sendnbsp();
-			space = SP_DONESPACE;
-		}	*/
 		boxstack[boxsp].style |= style;
 	} else {
 		boxstack[boxsp].style &= STYLE_DEBUG;
 	}
-	sendstyle(boxstack[boxsp].style);
+	
+	if(fg != OCOLOR_INHERIT) {
+		boxstack[boxsp].fgcolor = fg;
+	}
+	if(bg != OCOLOR_INHERIT) {
+		boxstack[boxsp].bgcolor = bg;
+	}
+	
+	sendstyle(boxstack[boxsp].style, boxstack[boxsp].fgcolor, boxstack[boxsp].bgcolor);
+}
+
+void o_set_style(int style) {
+	o_set_style_colors(style, OCOLOR_INHERIT, OCOLOR_INHERIT);
 }
 
 void o_set_upper() {
@@ -446,6 +459,8 @@ void o_reset(int force_w, int quirks) {
 	}
 	boxstack[boxsp].boxclass = CLA_MAIN;
 	boxstack[boxsp].style = STYLE_ROMAN;
+	boxstack[boxsp].fgcolor = OCOLOR_INITIAL;
+	boxstack[boxsp].bgcolor = OCOLOR_INITIAL;
 	boxstack[boxsp].upper = 0;
 	boxstack[boxsp].visible = 1;
 	boxstack[boxsp].wrap = !(term_handles_wrapping() || nowrap);

--- a/src/output.h
+++ b/src/output.h
@@ -9,6 +9,7 @@ void o_nospace(void);
 void o_nbsp(void);
 void o_sync(void);
 void o_set_style(int style);
+void o_set_style_colors(int style, int fg, int bg);
 void o_set_upper(void);
 void o_print_word(const char *utf8);
 void o_print_opaque_word(const char *utf8);

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -141,7 +141,7 @@ static void reset_bgcolor() { // Reset the background color after a newline
 }
 
 int term_sendlf() {
-	printf("\033[49m"); // Always reset background color before scrolling, to avoid weird behavior with the new line produced
+	if(isatty(1)) printf("\033[49m"); // Always reset background color before scrolling, to avoid weird behavior with the new line produced
 	fputc('\n', stdout);
 	reset_bgcolor();
 	if(io_tag_lines) printf("  ");

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -119,14 +119,17 @@ void term_effectstyle(int style) {
 }
 
 void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
+	int cat;
 	if(fg != termfg && isatty(1)) {
 		assert(fg != OCOLOR_INHERIT);
-		printf("\033[3%dm", fg);
+		cat = fg ? 9 : 3; // Use code 9X (bright colors) if not black; for black, use 3X (dim colors)
+		printf("\033[%d%dm", cat, fg);
 		termfg = fg;
 	}
 	if(bg != termbg && isatty(1)) {
 		assert(bg != OCOLOR_INHERIT);
-		printf("\033[4%dm", bg);
+		cat = bg ? 10 : 4; // Use code 10X (bright colors) if not black; for black, use 4X (dim colors)
+		printf("\033[%d%dm", cat, bg);
 		termbg = bg;
 	}
 }

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -111,6 +111,9 @@ void term_effectstyle(int style) {
 		if(style & STYLE_REVERSE) printf("\033[7m");
 		if(style & STYLE_DEBUG) printf("\033[36m");
 		if(style & STYLE_FIXED) printf("\033[50m"); // Not widely supported by terminals, but can be used by external tools
+		// This also clobbers the colors though
+		termfg = OCOLOR_INITIAL;
+		termbg = OCOLOR_INITIAL;
 	}
 	termstyle = style;
 }
@@ -118,12 +121,12 @@ void term_effectstyle(int style) {
 void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
 	if(fg != termfg && isatty(1)) {
 		assert(fg != OCOLOR_INHERIT);
-		if(fg != OCOLOR_INITIAL) printf("\033[3%dm", fg);
+		printf("\033[3%dm", fg);
 		termfg = fg;
 	}
 	if(bg != termbg && isatty(1)) {
 		assert(bg != OCOLOR_INHERIT);
-		if(bg != OCOLOR_INITIAL) printf("\033[4%dm", bg);
+		printf("\033[4%dm", bg);
 		termbg = bg;
 	}
 }

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -122,20 +122,28 @@ void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
 	int cat;
 	if(fg != termfg && isatty(1)) {
 		assert(fg != OCOLOR_INHERIT); // INHERIT should never get this far - we should only be sent actual colors at this stage
-		cat = fg ? 9 : 3; // Use code 9X (bright colors) if not black; for black, use 3X (dim colors)
+		cat = (fg == 0 || fg == 9) ? 3 : 9; // Use code 9X (bright colors) if not black; for black, use 3X (dim colors)
 		printf("\033[%d%dm", cat, fg);
 		termfg = fg;
 	}
 	if(bg != termbg && isatty(1)) {
 		assert(bg != OCOLOR_INHERIT);
-		cat = bg ? 10 : 4; // Use code 10X (bright colors) if not black; for black, use 4X (dim colors)
+		cat = (bg == 0 || bg == 9) ? 4 : 10; // Use code 10X (bright colors) if not black; for black, use 4X (dim colors)
 		printf("\033[%d%dm", cat, bg);
 		termbg = bg;
 	}
 }
 
+static void reset_bgcolor() { // Reset the background color after a newline
+	int bg = termbg;
+	termbg = OCOLOR_INITIAL;
+	term_colors(termfg, bg);
+}
+
 int term_sendlf() {
+	printf("\033[49m"); // Always reset background color before scrolling, to avoid weird behavior with the new line produced
 	fputc('\n', stdout);
+	reset_bgcolor();
 	if(io_tag_lines) printf("  ");
 	unread_lines++;
 	if(term_height > 1 && isatty(1)) {

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -121,7 +121,7 @@ void term_effectstyle(int style) {
 void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
 	int cat;
 	if(fg != termfg && isatty(1)) {
-		assert(fg != OCOLOR_INHERIT);
+		assert(fg != OCOLOR_INHERIT); // INHERIT should never get this far - we should only be sent actual colors at this stage
 		cat = fg ? 9 : 3; // Use code 9X (bright colors) if not black; for black, use 3X (dim colors)
 		printf("\033[%d%dm", cat, fg);
 		termfg = fg;

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -31,6 +31,7 @@ static struct histentry *tophist;
 static term_int_callback_t term_int_callback;
 static int unread_lines;
 static int termstyle;
+static int termfg = OCOLOR_INITIAL, termbg = OCOLOR_INITIAL;
 static int term_height;
 static int did_tcsetattr;
 static struct termios tio_orig;
@@ -112,6 +113,19 @@ void term_effectstyle(int style) {
 		if(style & STYLE_FIXED) printf("\033[50m"); // Not widely supported by terminals, but can be used by external tools
 	}
 	termstyle = style;
+}
+
+void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
+	if(fg != termfg && isatty(1)) {
+		assert(fg != OCOLOR_INHERIT);
+		if(fg != OCOLOR_INITIAL) printf("\033[3%dm", fg);
+		termfg = fg;
+	}
+	if(bg != termbg && isatty(1)) {
+		assert(bg != OCOLOR_INHERIT);
+		if(bg != OCOLOR_INITIAL) printf("\033[4%dm", bg);
+		termbg = bg;
+	}
 }
 
 int term_sendlf() {

--- a/src/term_winglk.c
+++ b/src/term_winglk.c
@@ -198,3 +198,6 @@ void term_effectstyle(int style) {
 		termstyle = style;
 	}
 }
+
+void term_colors(int fg, int bg) {
+}

--- a/src/term_winglk.c
+++ b/src/term_winglk.c
@@ -17,6 +17,7 @@ static int argc = 1;
 static char **argv;
 static term_int_callback_t term_int_callback;
 static int termstyle;
+static int termfg = OCOLOR_INITIAL, termbg = OCOLOR_INITIAL;
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 	if(InitGlk(0x00000601) == 0) exit(0);
@@ -28,8 +29,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 }
 
 int winglk_startup_code(const char* cmdline) {
-	int i;
-	
 	// There used to be an elaborate block of code here that took the LPSTRING command line provided by Windows and parsed it out into argc and argv
 	// But the parsing was quite basic (just splitting on every run of spaces) and didn't take into account things like quoting and escaping
 	// Since the Windows versions are only expected to be built with MinGW, we instead use MinGW's built-in way of accessing argc and argv directly
@@ -38,6 +37,7 @@ int winglk_startup_code(const char* cmdline) {
 	argv = __argv;
 	
 #if 0
+	int i;
 	printf("cmdline \"%s\"\n", cmdline);
 	for(i = 0; i < argc; i++) {
 		printf(" %d: \"%s\"\n", i, argv[i]);
@@ -199,5 +199,24 @@ void term_effectstyle(int style) {
 	}
 }
 
+// https://zspec.jaredreisinger.com/08-screen#8_3
+static int32_t ansi_to_glk_color[] = {
+	0x000000, // black
+	0xef0000, // red
+	0x00d000, // green
+	0xefef00, // yellow
+	0x006fb0, // blue
+	0xff00ff, // magenta
+	0x00efef, // cyan
+	0xffffff, // white
+	zcolor_Current, // inherit
+	zcolor_Default // initial
+};
+
 void term_colors(int fg, int bg) {
+	if(termfg != fg || termbg != bg) {
+		garglk_set_zcolors(ansi_to_glk_color[fg], ansi_to_glk_color[bg]);
+		termfg = fg;
+		termbg = bg;
+	}
 }

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -4,6 +4,9 @@
 #define TERM_RIGHT 132
 #define TERM_DELETE 133
 
+#define OCOLOR_INHERIT 8
+#define OCOLOR_INITIAL 9
+
 typedef void (*term_int_callback_t)();
 
 void term_init(term_int_callback_t callback);
@@ -20,6 +23,7 @@ void term_sendbytes(uint8_t *utf8, int nbyte);
 int term_sendlf(); // returns true if this involved a more prompt
 int term_sendfakelf(); // Do all the stuff surrounding a newline, but assume the newline was printed by something else already
 void term_effectstyle(int style);
+void term_colors(int fg, int bg);
 void term_clear(int all);
 
 int term_is_interactive(void);


### PR DESCRIPTION
The implementation is very basic at the moment: only supports eight named colors plus `initial` and `inherit`, and depending on the terminal may put the wrong color on the line following a div. But it allows printing text in green or red when unit tests pass or fail, and that's the main thing I expect people to use it for.