### PR TITLE
support colours in unit.dg

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -3,7 +3,7 @@ all: test
 DEBUG=../../src/dgdebug -u
 STDLIB=../../unit.dg ../../stdlib.dg
 
-test: time utils pass-1 fail-1
+test: time utils pass-1 fail-1 fatal-error
 
 time:
 	$(DEBUG) time-tests.dg time.dg $(STDLIB)
@@ -20,6 +20,10 @@ fail-1:
 	$(DEBUG) fail-1.dg $(STDLIB) \
 		 | grep "1 TEST FAILED." > /dev/null
 
+fatal-error:
+	$(DEBUG) fatal-error.dg $(STDLIB) \
+		 | grep "FATAL ERROR" > /dev/null
+
 clean:
 
-.PHONY: test all time clean
+.PHONY: test all clean time utils pass-1 fail-1 fatal-error

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -9,13 +9,16 @@ time:
 	$(DEBUG) time-tests.dg time.dg $(STDLIB)
 
 utils:
-	$(DEBUG) utils-tests.dg utils.dg $(STDLIB) | grep "3 TESTS FAILED."
+	$(DEBUG) utils-tests.dg utils.dg $(STDLIB) \
+		 | grep "3 TESTS FAILED." > /dev/null
 
 pass-1:
-	$(DEBUG) pass-1.dg $(STDLIB) | grep "1 test passed successfully."
+	$(DEBUG) pass-1.dg $(STDLIB) \
+		 | grep "1 test passed successfully." > /dev/null
 
 fail-1:
-	$(DEBUG) fail-1.dg $(STDLIB) | grep "1 TEST FAILED."
+	$(DEBUG) fail-1.dg $(STDLIB) \
+		 | grep "1 TEST FAILED." > /dev/null
 
 clean:
 

--- a/test/unit/fatal-error.dg
+++ b/test/unit/fatal-error.dg
@@ -3,20 +3,7 @@
 (list of tests [#bottles-of-beer])
 
 (bottles of beer $Bottles)
-	  (bottles of beer $FewerBottles) %% overflow the heap
-	  (if) ($Bottles > 1) (then)
-	        $Bottles bottles of beer on the wall, (line)
-			($Bottles minus 1 into $FewerBottles)
-			$Bottles bottles of beer. (line)
-			You take one down, and pass it around. (line)
-			$FewerBottles bottles of beer on the wall. (line)
-			(bottles of beer $FewerBottles)
-	  (else)
-		    One bottle of beer on the wall, (line)
-			one bottle of beer. (line)
-			You take it down, and pass it around. (line)
-			No more bottles of beer on the wall!
-	  (endif)
+	  (bottles of beer $Bottles) %% overflow the heap
 
 (test #bottles-of-beer)
 	  (bottles of beer 16383)

--- a/test/unit/fatal-error.dg
+++ b/test/unit/fatal-error.dg
@@ -1,0 +1,22 @@
+%% dgdebug -u fatal-error.dg unit.dg stdlib.dg
+
+(list of tests [#bottles-of-beer])
+
+(bottles of beer $Bottles)
+	  (bottles of beer $FewerBottles) %% overflow the heap
+	  (if) ($Bottles > 1) (then)
+	        $Bottles bottles of beer on the wall, (line)
+			($Bottles minus 1 into $FewerBottles)
+			$Bottles bottles of beer. (line)
+			You take one down, and pass it around. (line)
+			$FewerBottles bottles of beer on the wall. (line)
+			(bottles of beer $FewerBottles)
+	  (else)
+		    One bottle of beer on the wall, (line)
+			one bottle of beer. (line)
+			You take it down, and pass it around. (line)
+			No more bottles of beer on the wall!
+	  (endif)
+
+(test #bottles-of-beer)
+	  (bottles of beer 16383)

--- a/unit.dg
+++ b/unit.dg
@@ -21,6 +21,8 @@
 
 (keep running on failure) %% negate to stop at first failed test
 
+(using color) %% negate to use default output instead of green and red
+
 %% We can't just (exhaust *(test $)), because that actually runs each test
 %% without setup, cleanup, or failure checks, so we work around that with
 %% a global variable, populated with all the tests. You can quarantine tests
@@ -48,6 +50,14 @@
 	(bound $Thing2)
 	($Thing1 < $Thing2)
 
+(style class @green-bar)
+	   color: green;
+
+(style class @red-bar)
+	   color: red;
+
+(style class @no-color)
+
 (global variable (number of failures 0))
 
 (program entry point)
@@ -58,14 +68,13 @@
 	(no space) . (roman) (line)
 	(stoppable) (exhaust) {
 		*($Test is one of $Tests)
-		Testing $Test:
 		(run-test $Test)
 	}
 	(number of failures $Failures)
 	(if) ($Failures = 0) (then)
 		(bold) $Number test
 		(if) ($Number > 1) (then) (no space) s (endif)
-		passed successfully. (roman) (par)
+		(bold)  passed successfully. (roman) (par)
 		(quit 0)
 	(else)
 		(bold) $Failures TEST
@@ -80,20 +89,42 @@
 	(now) (number of failures $FailuresPlusOne)
 
 (run-test $Test)
+    (number of failures $Failures)
+	(if) ~(using color) (then)
+		Testing $Test :
+	(elseif) ($Failures = 0) (then)
+		(span @green-bar) { Testing $Test : }
+	(else)
+		(span @red-bar)   { Testing $Test : }
+	(endif)
 	(if)
 		(stoppable) (exhaust) *(set up $Test)   %% don't fail if absent
 		(test $Test)
 		(stoppable) (exhaust) *(clean up $Test) %% don't fail if absent
 	(then)
-		Passed! (line)
+		(if) ~(using color) (then)
+  		 	Passed! (line)
+		(elseif) ($Failures = 0) (then)
+			(span @green-bar) { Passed! (line) }
+		(else)
+ 			(span @red-bar)   { Passed! (line) }
+		(endif)
 	(else)
-		(bold) Failed. (roman) (space) :-\( (line)
+		(if) (using color) (then)
+		    (span @red-bar) {
+				  (bold) Failed. (roman) (space) :-\( (line)
+		    }
+		(else)
+			(bold) Failed. (roman) (space) :-\( (line)
+		(endif)
 		(increment failures)
 		(if) ~(keep running on failure) (then) (stop) (endif)
 	(endif)
 
 (error $Code entry point)
-	(bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
+	(div @red-bar) {
+		 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
+    }
 	(quit 2)
 
 %% patch for ($ contains sublist $) issues; delete when fixed

--- a/unit.dg
+++ b/unit.dg
@@ -122,9 +122,13 @@
 	(endif)
 
 (error $Code entry point)
-	(div @red-bar) {
-		 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
-    }
+    (if) (using color) (then)
+		(div @red-bar) {
+			 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
+        }
+	(else)
+			 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
+	(endif)
 	(quit 2)
 
 %% patch for ($ contains sublist $) issues; delete when fixed

--- a/unit.dg
+++ b/unit.dg
@@ -57,6 +57,8 @@
 	   color: red;
 
 (style class @no-color)
+	   color: initial;
+	   background-color: initial;
 
 (global variable (number of failures 0))
 
@@ -66,10 +68,12 @@
 	(bold) Attempting $Number test
 	(if) ($Number > 1) (then) (no space) s (endif)
 	(no space) . (roman) (line)
+	(if) (using color) (then) (body style @green-bar) (endif)
 	(stoppable) (exhaust) {
 		*($Test is one of $Tests)
 		(run-test $Test)
 	}
+	(body style @no-color)
 	(number of failures $Failures)
 	(if) ($Failures = 0) (then)
 		(bold) $Number test
@@ -87,48 +91,27 @@
     (number of failures $Failures)
 	($Failures plus 1 into $FailuresPlusOne)
 	(now) (number of failures $FailuresPlusOne)
+	(if) (using color) (then) (body style @red-bar) (endif)
 
 (run-test $Test)
-    (number of failures $Failures)
-	(if) ~(using color) (then)
-		Testing $Test :
-	(elseif) ($Failures = 0) (then)
-		(span @green-bar) { Testing $Test : }
-	(else)
-		(span @red-bar)   { Testing $Test : }
-	(endif)
+	Testing $Test :
 	(if)
 		(stoppable) (exhaust) *(set up $Test)   %% don't fail if absent
 		(test $Test)
 		(stoppable) (exhaust) *(clean up $Test) %% don't fail if absent
 	(then)
-		(if) ~(using color) (then)
-  		 	Passed! (line)
-		(elseif) ($Failures = 0) (then)
-			(span @green-bar) { Passed! (line) }
-		(else)
- 			(span @red-bar)   { Passed! (line) }
-		(endif)
+	 	Passed! (line)
 	(else)
-		(if) (using color) (then)
-		    (span @red-bar) {
-				  (bold) Failed. (roman) (space) :-\( (line)
-		    }
-		(else)
-			(bold) Failed. (roman) (space) :-\( (line)
-		(endif)
 		(increment failures)
+		(bold) Failed. (roman) (space) :-\( (line)
 		(if) ~(keep running on failure) (then) (stop) (endif)
 	(endif)
 
 (error $Code entry point)
-    (if) (using color) (then)
-		(div @red-bar) {
-			 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
-        }
-	(else)
-			 (bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
-	(endif)
+	(if) (using color) (then)
+		 (body style @red-bar)
+    (endif)
+	(bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
 	(quit 2)
 
 %% patch for ($ contains sublist $) issues; delete when fixed


### PR DESCRIPTION
Make `unit.dg` output in green until a test fails, and red thereafter. Include a switch to turn off the colours if desired.

For some reason, (body style $) isn't working in the debugger, which made this uglier than it had to be.