### PR TITLE
Implement (body style $), (reset body style), (current div height $) in debugger

### DIFF
--- a/src/dumb_output.c
+++ b/src/dumb_output.c
@@ -5,6 +5,7 @@
 #include "report.h"
 
 static int force_width;
+static int force_height;
 
 static void bail_out() {
 	report(LVL_ERR, 0, "Output is not allowed during initial value evaluation.");
@@ -37,6 +38,7 @@ void o_post_input(int external_lf)		{ bail_out(); }
 
 void o_reset(int force_w, int force_h, int quirks) {
 	force_width = force_w;
+	force_height = force_h;
 }
 
 void o_leave_all() {
@@ -47,4 +49,8 @@ void o_cleanup() {
 
 int o_get_width() {
 	return force_width? force_width : 79;
+}
+
+int o_get_height() {
+	return force_height? force_height : 0;
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -1206,13 +1206,13 @@ static int eval_compute(struct eval_state *es, int op, int a, int b, int *res) {
 		break;
 	case BI_DIV_WIDTH:
 		r = o_get_width();
-		if(r < 0) return 0;
+		if(r <= 0) return 0;
 		*res = r;
 		return 1;
 		break;
 	case BI_DIV_HEIGHT:
 		r = o_get_height();
-		if(r < 0) return 0;
+		if(r <= 0) return 0;
 		*res = r;
 		return 1;
 		break;

--- a/src/eval.c
+++ b/src/eval.c
@@ -537,7 +537,7 @@ static value_t value_of(value_t v, struct eval_state *es) {
 		env = &es->envstack[es->env];
 		assert(v.value < env->nvar);
 		return env->vars[v.value];
-	case OPER_BOX: // Only for BI_GLOBAL_STYLE, currently unimplemented
+	case OPER_BOX: // Only for BI_GLOBAL_STYLE
 	case VAL_NUM:
 	case VAL_OBJ:
 	case VAL_DICT:
@@ -1205,10 +1205,16 @@ static int eval_compute(struct eval_state *es, int op, int a, int b, int *res) {
 		}
 		break;
 	case BI_DIV_WIDTH:
-		*res = o_get_width();
+		r = o_get_width();
+		if(r < 0) return 0;
+		*res = r;
 		return 1;
 		break;
-	case BI_DIV_HEIGHT: // Not exposed by output.c; it could be in the future, but for now, just fail
+	case BI_DIV_HEIGHT:
+		r = o_get_height();
+		if(r < 0) return 0;
+		*res = r;
+		return 1;
 		break;
 	default:
 		printf("unimplemented computation %d\n", op);
@@ -1219,6 +1225,7 @@ static int eval_compute(struct eval_state *es, int op, int a, int b, int *res) {
 }
 
 static int eval_builtin(struct eval_state *es, int builtin, value_t o1, value_t o2) {
+	int fg, bg, st;
 	assert(builtin);
 	switch(builtin) {
 	case BI_BOLD:
@@ -1253,8 +1260,24 @@ static int eval_builtin(struct eval_state *es, int builtin, value_t o1, value_t 
 			o_set_style(STYLE_FIXED);
 		}
 		break;
-	case BI_GLOBAL_STYLE: // Not currently supported, but could be
+	case BI_GLOBAL_STYLE:
 	case BI_GLOBAL_UNSTYLE:
+		if(es->divsp) { // Crash if in a box OR in a span
+			return ESTATUS_ERR_IO;
+		}
+		if(builtin == BI_GLOBAL_STYLE) {
+			fg = eval_color(es->program->boxclasses[o1.value].color, OCOLOR_INITIAL);
+			bg = eval_color(es->program->boxclasses[o1.value].bgcolor, OCOLOR_INITIAL);
+			st = es->program->boxclasses[o1.value].style;
+		} else {
+			fg = OCOLOR_INITIAL;
+			bg = OCOLOR_INITIAL;
+			st = STYLE_ROMAN;
+		}
+		es->divfg = fg;
+		es->divbg = bg;
+		es->divstyle = st;
+		o_set_style_colors(es->divstyle, es->divfg, es->divbg);
 		break;
 	case BI_ITALIC:
 		if(!es->forwords) {

--- a/src/output.c
+++ b/src/output.c
@@ -497,3 +497,7 @@ void o_cleanup() {
 int o_get_width() {
 	return width;
 }
+
+int o_get_height() {
+	return height;
+}

--- a/src/output.h
+++ b/src/output.h
@@ -25,3 +25,4 @@ void o_reset(int force_width, int force_height, int quirks);
 void o_leave_all(void);
 void o_cleanup(void);
 int o_get_width(void);
+int o_get_height(void);


### PR DESCRIPTION
These don't work _great_ in the debugger, but they do work to the specification, so there's no reason not to allow them.

Note, however, that the debugger does _not_ support `(clear)`, which limits the effectiveness of body styles.

<img width="1408" height="381" alt="image" src="https://github.com/user-attachments/assets/2fd4091f-f7c1-42c3-9aaf-724fd2e7d7e7" />