### PR TITLE
display actual test output in default, not red or green

### DIFF
--- a/test/unit/fail-1.dg
+++ b/test/unit/fail-1.dg
@@ -1,4 +1,4 @@
-%% dgdebug -q fail-1.dg unit.dg stdlib.dg
+%% dgdebug -u fail-1.dg unit.dg stdlib.dg
 
 (list of tests [
 	#intentionally-fail-this-test

--- a/test/unit/pass-1.dg
+++ b/test/unit/pass-1.dg
@@ -1,4 +1,4 @@
-%% dgdebug -q pass-1.dg unit.dg stdlib.dg
+%% dgdebug -u pass-1.dg unit.dg stdlib.dg
 
 (list of tests [
 	#pass-this-test

--- a/test/unit/time-tests.dg
+++ b/test/unit/time-tests.dg
@@ -1,4 +1,4 @@
-%% dgdebug -q time-tests.dg time.dg ../../unit.dg ../../stdlib.dg
+%% dgdebug -u time-tests.dg time.dg ../../unit.dg ../../stdlib.dg
 
 %% Here's a worked example of some unit tests for a Dialog extension.
 %% By convention, the top line of the test file specifies the command

--- a/test/unit/utils-tests.dg
+++ b/test/unit/utils-tests.dg
@@ -1,4 +1,4 @@
-%% dgdebug -q utils-tests.dg utils.dg unit.dg stdlib.dg
+%% dgdebug -u utils-tests.dg utils.dg unit.dg stdlib.dg
 
 (list of tests [
 	#take-last-n

--- a/unit.dg
+++ b/unit.dg
@@ -56,10 +56,6 @@
 (style class @red-bar)
 	   color: red;
 
-(style class @no-color)
-	   color: initial;
-	   background-color: initial;
-
 (global variable (number of failures 0))
 
 (program entry point)
@@ -68,12 +64,11 @@
 	(bold) Attempting $Number test
 	(if) ($Number > 1) (then) (no space) s (endif)
 	(no space) . (roman) (line)
-	(if) (using color) (then) (body style @green-bar) (endif)
 	(stoppable) (exhaust) {
 		*($Test is one of $Tests)
 		(run-test $Test)
 	}
-	(body style @no-color)
+	(reset body style)
 	(number of failures $Failures)
 	(if) ($Failures = 0) (then)
 		(bold) $Number test
@@ -87,22 +82,37 @@
 		(quit 1)
 	(endif)
 
+(update body style)
+	(if) (using color) (then)
+		 (number of failures $Failures)
+		 (if) ($Failures = 0) (then)
+		 	  (body style @green-bar)
+		 (else)
+		 	  (body style @red-bar)
+		 (endif)
+	(else)
+		 (reset body style)
+	(endif)
+
 (increment failures)
     (number of failures $Failures)
 	($Failures plus 1 into $FailuresPlusOne)
 	(now) (number of failures $FailuresPlusOne)
-	(if) (using color) (then) (body style @red-bar) (endif)
 
 (run-test $Test)
+	(update body style)
 	Testing $Test :
+	(reset body style) %% display output from the test itself in default colours
 	(if)
 		(stoppable) (exhaust) *(set up $Test)   %% don't fail if absent
 		(test $Test)
 		(stoppable) (exhaust) *(clean up $Test) %% don't fail if absent
 	(then)
+		(update body style)
 	 	Passed! (line)
 	(else)
 		(increment failures)
+		(update body style)
 		(bold) Failed. (roman) (space) :-\( (line)
 		(if) ~(keep running on failure) (then) (stop) (endif)
 	(endif)


### PR DESCRIPTION
When a unit test generates output, generate it in the default body style, not the unit test green or red. Assertions will stand out better, and the code may be playing with colour output itself.