### PR TITLE
summarize failing tests at end of unit.dg run

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -10,15 +10,15 @@ time:
 
 utils:
 	$(DEBUG) utils-tests.dg utils.dg $(STDLIB) \
-		 | grep "3 TESTS FAILED." > /dev/null
+		 | grep "3 TESTS FAILED" > /dev/null
 
 pass-1:
 	$(DEBUG) pass-1.dg $(STDLIB) \
-		 | grep "1 test passed successfully." > /dev/null
+		 | grep "1 test passed successfully" > /dev/null
 
 fail-1:
 	$(DEBUG) fail-1.dg $(STDLIB) \
-		 | grep "1 TEST FAILED." > /dev/null
+		 | grep "1 TEST FAILED" > /dev/null
 
 fatal-error:
 	$(DEBUG) fatal-error.dg $(STDLIB) \

--- a/test/unit/utils.dg
+++ b/test/unit/utils.dg
@@ -19,6 +19,8 @@
 
 (interface ($<Number is odd))
 
+(interface ($<Number is even))
+
 %%------------------------------ IMPLEMENTATION ------------------------------
 
 (take last $N from $List into $Suffix)
@@ -77,3 +79,5 @@
 	($Num modulo 2 into $Mod)
 	($Mod = 1)
 
+($Num is even)
+	~($Num is odd)

--- a/unit.dg
+++ b/unit.dg
@@ -23,6 +23,8 @@
 
 (using color) %% negate to use default output instead of green and red
 
+~(list failing tests) %% un-negate to summarize failing tests at the end
+
 %% We can't just (exhaust *(test $)), because that actually runs each test
 %% without setup, cleanup, or failure checks, so we work around that with
 %% a global variable, populated with all the tests. You can quarantine tests
@@ -56,7 +58,7 @@
 (style class @red-bar)
 	   color: red;
 
-(global variable (number of failures 0))
+(global variable (list of failures []))
 
 (program entry point)
 	(list of tests $Tests)
@@ -69,23 +71,28 @@
 		(run-test $Test)
 	}
 	(reset body style)
-	(number of failures $Failures)
-	(if) ($Failures = 0) (then)
+	(list of failures $Failures)
+	(if) ($Failures = []) (then)
 		(bold) $Number test
 		(if) ($Number > 1) (then) (no space) s (endif)
 		(bold)  passed successfully. (roman) (par)
 		(quit 0)
 	(else)
-		(bold) $Failures TEST
-		(if) ($Failures > 1) (then) (no space) S (endif)
-		FAILED. (roman) (par)
+		(length of $Failures into $Num)
+		(bold) $Num TEST
+		(if) ($Num > 1) (then) (no space) S (endif)
+		FAILED
+		(if) (list failing tests) (then)
+			 (roman) $Failures (bold)
+		(endif)
+		(no space) . (roman) (par)
 		(quit 1)
 	(endif)
 
 (update body style)
 	(if) (using color) (then)
-		 (number of failures $Failures)
-		 (if) ($Failures = 0) (then)
+		 (list of failures $Failures)
+		 (if) ($Failures = []) (then)
 		 	  (body style @green-bar)
 		 (else)
 		 	  (body style @red-bar)
@@ -94,10 +101,14 @@
 		 (reset body style)
 	(endif)
 
-(increment failures)
-    (number of failures $Failures)
-	($Failures plus 1 into $FailuresPlusOne)
-	(now) (number of failures $FailuresPlusOne)
+($Test has failed)
+	(list of failures $List)
+	(if) ($List = []) (then)
+		 ($ListPlusTest = [$Test])
+	(else)
+		 (append $List [$Test] $ListPlusTest)
+	(endif)
+	(now) (list of failures $ListPlusTest)
 
 (run-test $Test)
 	(update body style)
@@ -111,7 +122,7 @@
 		(update body style)
 	 	Passed! (line)
 	(else)
-		(increment failures)
+		($Test has failed)
 		(update body style)
 		(bold) Failed. (roman) (space) :-\( (line)
 		(if) ~(keep running on failure) (then) (stop) (endif)


### PR DESCRIPTION
Output a summary of the tests that failed at the end of a `test.dg` run, and provide a mechanism for turning this behaviour off.