### PR TITLE
don't print header when running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tidy:
 clean: tidy
 	$(MAKE) -C src clean
 
-install: test
+install: src/dialogc src/dgdebug
 	$(MAKE) -C src install
 
 uninstall:

--- a/readme.txt
+++ b/readme.txt
@@ -138,8 +138,9 @@ Release notes:
 		Debugger: terminal width will now be measured immediately after
 		launching.
 		
-		Debugger: --unit-test option is equivalent to --no-warn-not-topic
-		--quit --height=-1, but much shorter to type.
+		Debugger: --unit-test option is equivalent to --no-header
+		--no-warn-not-topic --quit --height=-1, but much shorter
+		to type.
 		
 		Library: new commands SUPERBRIEF, BRIEF, VERBOSE, and SUPERVERBOSE
 		change how rooms are described while going. The default behavior

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1328,7 +1328,8 @@ void usage(char *prgname) {
 	fprintf(stderr, "--numbered  -N      Show call depth with numbers during tracing.\n");
 	fprintf(stderr, "--tag-lines -T      Prepend output with \"  \", input with \"> \" or \") \".\n");
 	fprintf(stderr, "--no-header         Don't show version information at startup.\n");
-	fprintf(stderr, "--unit-test -u      Same as --no-warn-not-topic --quit --height=-1.\n");
+	fprintf(stderr, "--unit-test -u      Same as --no-warn-not-topic --quit --height=-1\n");
+	fprintf(stderr, "                    --no-header.\n");
 }
 
 extern int topic_warning_level; // Defined in frontend.c

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1428,6 +1428,7 @@ int debugger(int argc, char **argv) {
 				topic_warning_level = 2;
 				quitopt = 1;
 				force_height = -1;
+				suppress_header = 1;
 				break;
 			default:
 				if(opt >= 0) {

--- a/test/simple/language/Makefile
+++ b/test/simple/language/Makefile
@@ -5,7 +5,7 @@ DIFF = diff --ignore-space-change
 # Base of the repository
 BASEPATH = ../../..
 DGDEBUG = $(BASEPATH)/src/dgdebug
-DEBUG = $(DGDEBUG) -q --no-warn-not-topic
+DEBUG = $(DGDEBUG) -u
 
 # List of all .nolib.dg and .lib.dg files with .dg changed to .test
 tests := $(patsubst %.dg,%.test,$(wildcard *.dg))


### PR DESCRIPTION
There's no reason to print the `dgdebug` banner when running a suite of unit tests, and the instruction in it to type "help" at the debugger prompt is inappropriate. Make `-u` also include `--no-header`.