### PR TITLE
handle pathological case of 0 tests in unit.dg

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -3,7 +3,7 @@ all: test
 DEBUG=../../src/dgdebug -u
 STDLIB=../../unit.dg ../../stdlib.dg
 
-test: time utils pass-1 fail-1 fatal-error
+test: time utils pass-1 fail-1 zero-tests fatal-error
 
 time:
 	$(DEBUG) time-tests.dg time.dg $(STDLIB)
@@ -20,10 +20,15 @@ fail-1:
 	$(DEBUG) fail-1.dg $(STDLIB) \
 		 | grep "1 TEST FAILED" > /dev/null
 
+zero-tests:
+	$(DEBUG) zero-tests.dg $(STDLIB) \
+		 | grep "0 tests passed successfully" > /dev/null
+
 fatal-error:
 	$(DEBUG) fatal-error.dg $(STDLIB) \
 		 | grep "FATAL ERROR" > /dev/null
 
 clean:
+	rm -f *~ \#*\#
 
 .PHONY: test all clean time utils pass-1 fail-1 fatal-error

--- a/test/unit/zero-tests.dg
+++ b/test/unit/zero-tests.dg
@@ -1,0 +1,1 @@
+(list of tests [])

--- a/unit.dg
+++ b/unit.dg
@@ -64,7 +64,7 @@
 	(list of tests $Tests)
 	(length of $Tests into $Number)
 	(bold) Attempting $Number test
-	(if) ($Number > 1) (then) (no space) s (endif)
+	(if) ~($Number = 1) (then) (no space) s (endif)
 	(no space) . (roman) (line)
 	(stoppable) (exhaust) {
 		*($Test is one of $Tests)
@@ -74,13 +74,13 @@
 	(list of failures $Failures)
 	(if) ($Failures = []) (then)
 		(bold) $Number test
-		(if) ($Number > 1) (then) (no space) s (endif)
+		(if) ~($Number = 1) (then) (no space) s (endif)
 		(bold)  passed successfully. (roman) (par)
 		(quit 0)
 	(else)
 		(length of $Failures into $Num)
 		(bold) $Num TEST
-		(if) ($Num > 1) (then) (no space) S (endif)
+		(if) ~($Num = 1) (then) (no space) S (endif)
 		FAILED
 		(if) (list failing tests) (then)
 			 (roman) $Failures (bold)


### PR DESCRIPTION
Report `0 tests` instead of `0 test` in output from `unit.dg` in the event of an empty test list.