### PR TITLE
Ensure boxes are closed before calling o_reset

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1147,12 +1147,16 @@ static void cmd_restore(struct debugger *dbg) {
 
 static void cmd_more(struct debugger *dbg) {
 	force_height = 0;
+	o_end_box();
 	o_reset(force_width, force_height, dfrotz_quirks);
+	o_begin_box("debugger"); // Because the debugger will attempt to end it again after this
 }
 
 static void cmd_nomore(struct debugger *dbg) {
 	force_height = -1;
+	o_end_box();
 	o_reset(force_width, force_height, dfrotz_quirks);
+	o_begin_box("debugger"); // Because the debugger will attempt to end it again after this
 }
 
 struct debugcmd {

--- a/src/output.c
+++ b/src/output.c
@@ -8,7 +8,6 @@
 #include "output.h"
 #include "terminal.h"
 #include "unicode.h"
-#include "report.h"
 
 enum {
 	SP_AUTO = 0,
@@ -71,6 +70,7 @@ static void update_size() {
 	term_get_size(&w, &h, force_width, force_height);
 	if(force_width) w = force_width;
 	if(force_height) h = force_height;
+	if(w < 1) w = 79; // Can happen if the terminal is unable to supply an answer (in particular, the pseudo-tty in emacs can't provide a size immediately on startup)
 	if(w < width) syncwrap();
 	width = w;
 	height = h;
@@ -190,11 +190,6 @@ void o_par() {
 }
 
 void o_begin_box(char *boxclass) {
-	
-	if(!strcmp(boxclass, "intdebugger")) { // For testing
-		report(LVL_WARN, 0, "Dimensions: %d by %d", width, height);
-	}
-	
 	if(boxsp == nalloc_box - 1) {
 		nalloc_box = 2 * boxsp + 8;
 		boxstack = realloc(boxstack, nalloc_box * sizeof(struct boxstate));

--- a/src/output.c
+++ b/src/output.c
@@ -176,7 +176,7 @@ void o_line() {
 void o_par_n(int n) {
 	if(!boxstack[boxsp].visible) return;
 
-	if(height && n > height) n = height;
+	if(height > 0 && n > height) n = height;
 	o_line();
 	while(space < SP_DONELINE + n) {
 		sendlf();

--- a/src/output.c
+++ b/src/output.c
@@ -8,6 +8,7 @@
 #include "output.h"
 #include "terminal.h"
 #include "unicode.h"
+#include "report.h"
 
 enum {
 	SP_AUTO = 0,

--- a/src/output.c
+++ b/src/output.c
@@ -189,6 +189,11 @@ void o_par() {
 }
 
 void o_begin_box(char *boxclass) {
+	
+	if(!strcmp(boxclass, "intdebugger")) { // For testing
+		report(LVL_WARN, 0, "Dimensions: %d by %d", width, height);
+	}
+	
 	if(boxsp == nalloc_box - 1) {
 		nalloc_box = 2 * boxsp + 8;
 		boxstack = realloc(boxstack, nalloc_box * sizeof(struct boxstate));

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -12,7 +12,7 @@
 	#include <termios.h>
 	#define NEVER_A_TTY 0
 #else
-	#define NEVER_A_TTY 1
+	#define NEVER_A_TTY 1 // The fancy line-editing doesn't work on Windows (which lacks ANSI escapes), so we just pretend that a Windows terminal is never interactive, and therefore should not do anything fancy and readlineish
 #endif
 
 #include "common.h"
@@ -166,8 +166,8 @@ int term_sendlf() {
 	int savedbg = termbg;
 	term_colors(termfg, OCOLOR_INITIAL); // Set the background color to INITIAL before anything that might scroll the screen, so that the next line is filled with INITIAL instead of anything else
 	fputc('\n', stdout);
-	term_colors(termfg, savedbg);
 	if(io_tag_lines) printf("  ");
+	term_colors(termfg, savedbg);
 	unread_lines++;
 	if(term_height > 0 && isatty(1)) {
 		if(unread_lines >= term_height - 1) {

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -112,9 +112,9 @@ void term_effectstyle(int style) {
 		if(style & STYLE_BOLD) printf("\033[1m");
 		if(style & STYLE_ITALIC) printf("\033[4m");
 		if(style & STYLE_REVERSE) printf("\033[7m");
-		if(style & STYLE_DEBUG) printf("\033[36m");
+		if(style & STYLE_DEBUG) printf("\033[36m"); // Cyan
 		if(style & STYLE_FIXED) printf("\033[50m"); // Not widely supported by terminals, but can be used by external tools
-		// This also clobbers the colors though
+		// This also clobbers the colors though, so we should set them again
 		termfg = OCOLOR_INITIAL;
 		termbg = OCOLOR_INITIAL;
 	}
@@ -137,19 +137,14 @@ void term_colors(int fg, int bg) { // OCOLOR_* = ANSI escape color (0-7 or 9)
 	}
 }
 
-static void reset_bgcolor() { // Reset the background color after a newline
-	int bg = termbg;
-	termbg = OCOLOR_INITIAL;
-	term_colors(termfg, bg);
-}
-
 int term_sendlf() {
-	if(isatty(1)) printf("\033[49m"); // Always reset background color before scrolling, to avoid weird behavior with the new line produced
+	int savedbg = termbg;
+	term_colors(termfg, OCOLOR_INITIAL); // Set the background color to INITIAL before anything that might scroll the screen, so that the next line is filled with INITIAL instead of anything else
 	fputc('\n', stdout);
-	reset_bgcolor();
+	term_colors(termfg, savedbg);
 	if(io_tag_lines) printf("  ");
 	unread_lines++;
-	if(term_height > 1 && isatty(1)) {
+	if(term_height > 0 && isatty(1)) {
 		if(unread_lines >= term_height - 1) {
 			term_effectstyle(0);
 			fflush(stdout);


### PR DESCRIPTION
An oversight in the `@more` and `@nomore` commands led to colors bleeding onto the next line. This PR should fix that by closing the debugger box before resetting the terminal.