### PR TITLE
Work toward feature parity between Windows TTY and Mac/Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: make
         run: make --directory=./src
       - name: make (windows)
-        run: make --directory=./src dgdebug.exe dgdebug_tty.exe dialogc.exe
+        run: make --directory=./src dgdebug.exe dgdebug_gui.exe dialogc.exe
       - name: make test
         run: make test
       - name: make test-6502
@@ -48,7 +48,7 @@ jobs:
           name: win32
           path: |
             src/dgdebug.exe
-            src/dgdebug_tty.exe
+            src/dgdebug_gui.exe
             src/dialogc.exe
 
   build-manual:

--- a/license.txt
+++ b/license.txt
@@ -26,8 +26,8 @@ The test cases in the development repository (not included in the official
 releases) are released under the same license unless otherwise specified.
 See the LICENSE.txt files in the individual test directories for details.
 
-The Windows version of the Dialog Interactive Debugger (dgdebug) uses Windows
-Glk by David Kinder. A header file, and two precompiled libraries are
+The GUI version of the Dialog Interactive Debugger (dgdebug) uses Windows
+Glk by David Kinder. A header file and two precompiled libraries are
 distributed as part of this archive, under to the following (MIT) license:
 
 	WinGlk.h

--- a/manual/modules/ROOT/pages/software.adoc
+++ b/manual/modules/ROOT/pages/software.adoc
@@ -9,8 +9,8 @@ Versions from 2025 onward can be found here:
 {home-page}
 
 The archive contains the full source code for the Dialog compiler and
-interactive debugger, as well as pre-built executable files for Linux (i386 and
-x86_64) and Windows. The compiler is called `dialogc`, and the debugger
+interactive debugger, as well as pre-built executable files for Linux
+(x86_64) and Windows. The compiler is called `dialogc`, and the debugger
 is called `dgdebug`.
 
 Alternately, if you are on OS X, you can install the
@@ -28,9 +28,9 @@ command-line shell. Depending on what operating system you use, you may have to
 copy the executable files to a system-specific location, or simply navigate to
 the directory that contains them.
 
-The Windows version of the debugger makes use of a third-party library,
-_Windows Glk_ by David Kinder. Make sure to put the two included `DLL`
-files in the same directory as the executable file (`dgdebug.exe`).
+The graphical version of the debugger on Windows makes use of a third-party
+library, _Windows Glk_ by David Kinder. Make sure to put the two included `DLL`
+files in the same directory as the executable file (`dgdebug_gui.exe`).
 
 To check that everything is in place, try the following two commands:
 
@@ -215,8 +215,8 @@ This can be used to inspect or control the
 running program.
 
 The debugger remains operational after your program terminates. To start over,
-type `(restart)`. To quit the debugger, either press Control-D (Linux),
-close the window (Windows), or type the special command `@quit`.
+type `(restart)`. To quit the debugger, press Control-D (terminal),
+close the window (GUI), or type the special command `@quit`.
 
 === Modifying a running game
 
@@ -314,10 +314,9 @@ prompt. These commands can be abbreviated as long as the abbreviation is unique;
 
 === Suspending execution
 
-The terminal version of the debugger (i.e. _not_ the Windows Glk version) allows
-you to suspend a running computation by pressing Control-C at any time. This
-will immediately take you to a prompt where you can type queries and debugging
-commands.
+The terminal version of the debugger allows you to suspend a running computation
+by pressing Control-C at any time. This will immediately take you to a prompt
+where you can type queries and debugging commands.
 
 To resume execution, type a blank line at this prompt.
 
@@ -411,4 +410,3 @@ system-wide location, type “`sudo make install`”.
 
 The Windows binaries can be cross-compiled on a Linux system using the
 `Mingw32` toolchain.
-

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ Cross-compiling the Windows version of the software under Linux (requires
 mingw32):
 
 	cd src
-	make dialogc.exe dgdebug.exe
+	make dialogc.exe dgdebug.exe dgdebug_gui.exe
 
 Project website:
 
@@ -41,10 +41,14 @@ Project website:
 Release notes:
 
 	1b/01, Lib 1.1.1:
-  
+	
 		Due to new built-in predicates in this release, all projects
 		compiled for Å-machine will need version 1.0.0 or later of the
 		Å-machine tools. Get them from github.com/Dialog-IF/aamachine/.
+		
+		Note that the debugger will now use the terminal on Windows,
+		rather than opening its own graphical window. To get the old
+		behavior, run dgdebug_gui.exe instead of dgdebug.exe.
 		
 		Language: deprecated display:none; on spans. This remains legal,
 		but will produce a warning.
@@ -63,6 +67,9 @@ Release notes:
 		
 		Language: added a way to test for basic style support, basic
 		color support, and text alignment support.
+		
+		Distribution: introduced a terminal version of the debugger on
+		Windows, equivalent to the Mac and Linux versions.
 		
 		Distribution: added unit.dg, a library for unit testing.
 		

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,12 +39,13 @@ dgdebug:		debugger.o frontend.o report.o arena.o ast.o parse.o compile.o eval.o 
 dialogc.exe:		frontend.c backend_z.c runtime_z.c blorb.c dumb_output.c dumb_report.c arena.c ast.c parse.c compile.c eval.c accesspred.c unicode.c backend.c aavm.c backend_aa.c crc32.c ifid.c
 			${MINGW32} ${CFLAGS} -o $@ $^
 
-dgdebug.exe:		debugger.c frontend.c report.c arena.c ast.c parse.c compile.c eval.c accesspred.c output.c unicode.c term_winglk.c winglk-res.o fs_winglk.c
-			${MINGW32} -L ${WINLIB} -I ${WININCLUDE} ${CFLAGS} -o $@ $^ -lGlk
-
-# A stripped-down version of dgdebug that runs in the Windows terminal, for use with things like dgt
-dgdebug_tty.exe:	debugger.c frontend.c report.c arena.c ast.c parse.c compile.c eval.c term_tty.c accesspred.c output.c unicode.c fs_tty.c
+# Terminal version
+dgdebug.exe:	debugger.c frontend.c report.c arena.c ast.c parse.c compile.c eval.c term_tty.c accesspred.c output.c unicode.c fs_tty.c
 			${MINGW32} ${CFLAGS} -o $@ $^
+
+# Windows Glk version
+dgdebug_gui.exe:		debugger.c frontend.c report.c arena.c ast.c parse.c compile.c eval.c accesspred.c output.c unicode.c term_winglk.c winglk-res.o fs_winglk.c
+			${MINGW32} -L ${WINLIB} -I ${WININCLUDE} ${CFLAGS} -o $@ $^ -lGlk
 
 winglk-res.o:		winglk-res.rc winglk-res.manifest
 			${WINDRES} $< $@

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -446,7 +446,7 @@ int term_getkey(const char *prompt) {
 	fflush(stdout);
 
 	if(NEVER_A_TTY || !isatty(0)) {
-		unread_lines = 0; // Usually doesn't matter if !isatty(0) but does on Windows
+		if(isatty(0)) unread_lines = 0; // For Windows specifically
 		ch = fgetc(stdin);
 		return (ch == EOF)? -1 : ch;
 	}
@@ -498,7 +498,7 @@ int term_getline(const char *prompt, uint8_t *buffer, int bufsize, int is_filena
 	fflush(stdout);
 
 	if(NEVER_A_TTY || !isatty(0)) {
-		unread_lines = 0; // Usually doesn't matter if !isatty(0) but does on Windows
+		if(isatty(0)) unread_lines = 0; // For Windows specifically
 		if(fgets((char *) buffer, bufsize, stdin)) {
 			len = strlen((char *) buffer);
 			if(len && buffer[len - 1] == '\n') buffer[--len] = 0;

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -7,12 +7,13 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
-#ifndef _WIN32
+#ifdef _WIN32
+	#include <windows.h>
+	#define NEVER_A_TTY 1 // Windows doesn't support messing with line echoing, so we let the shell handle history and line editing by pretending it's not a TTY
+#else
 	#include <sys/ioctl.h>
 	#include <termios.h>
 	#define NEVER_A_TTY 0
-#else
-	#define NEVER_A_TTY 1 // The fancy line-editing doesn't work on Windows (which lacks ANSI escapes), so we just pretend that a Windows terminal is never interactive, and therefore should not do anything fancy and readlineish
 #endif
 
 #include "common.h"
@@ -40,13 +41,16 @@ static int termfg = OCOLOR_INITIAL, termbg = OCOLOR_INITIAL;
 static int term_height;
 static int force_height;
 static uint16_t last_filename[256];
-#ifndef _WIN32
+#ifdef _WIN32
+static volatile int interrupt_flag; // Since Windows puts signal handlers in a separate thread
+#else
 static int did_tcsetattr;
 static struct termios tio_orig;
 #endif
 
 void tty_setup() {
-#ifndef _WIN32
+#ifdef _WIN32
+#else
 	struct termios tio;
 
 	if(!tcgetattr(0, &tio)) {
@@ -66,7 +70,8 @@ void tty_setup() {
 }
 
 void tty_restore() {
-#ifndef _WIN32
+#ifdef _WIN32
+#else
 	if(did_tcsetattr) {
 		tcsetattr(0, TCSANOW, &tio_orig);
 		did_tcsetattr = 0;
@@ -75,6 +80,13 @@ void tty_restore() {
 }
 
 void term_ticker() {
+#ifdef _WIN32
+	if(interrupt_flag) {
+		term_int_callback();
+		interrupt_flag = 0;
+	}
+#else
+#endif
 }
 
 void morefunc() {
@@ -95,21 +107,30 @@ void morefunc() {
 
 void term_get_size(int *width, int *height, int force_w, int force_h) {
 	char *envvar;
-#ifndef _WIN32
+#ifdef _WIN32
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+#else
 	struct winsize ws;
 #endif
 	
 	force_height = force_h;
 	*width = 0; *height = 0;
 	
-#ifndef _WIN32
+#ifdef _WIN32
+	// https://stackoverflow.com/a/12642749/3233017
+	if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+		*width = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+		if(io_tag_lines) *width -= 2; // For the tags
+		*height = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	}
+#else
 	if(!ioctl(0, TIOCGWINSZ, &ws)) {
 		*width = (ws.ws_col >= 1)? ws.ws_col - 1 : 0;
 		if(io_tag_lines) *width -= 2; // For the tags
 		*height = ws.ws_row;
 	}
 #endif
-	if(*width <= 0) { // Could not calculate: TIOCGWINSZ was not available, did not succeed, or returned 0
+	if(*width <= 0) { // Could not calculate: platform window size query was not available, did not succeed, or returned 0
 		envvar = getenv("COLUMNS");
 		if(envvar) *width = atoi(envvar);
 		if(*width == 0) *width = 79;
@@ -343,7 +364,15 @@ static int getkey() {
 	}
 }
 
-#ifndef _WIN32
+#ifdef _WIN32
+static BOOL WINAPI sighandler(DWORD sig) {
+	if(sig == CTRL_C_EVENT) {
+		interrupt_flag = 1;
+		return TRUE;
+	}
+	return FALSE;
+}
+#else
 static void sighandler(int sig) {
 	if(sig == SIGINT) {
 		term_int_callback();
@@ -353,14 +382,19 @@ static void sighandler(int sig) {
 
 void term_init(term_int_callback_t callback) {
 	term_int_callback = callback;
-#ifndef _WIN32
 	if(isatty(0)) {
+#ifdef _WIN32
+		if(!SetConsoleCtrlHandler((PHANDLER_ROUTINE)sighandler, TRUE)) {
+			fprintf(stderr, "Failed to install signal handler for ^C.\n");
+			exit(1);
+		}
+#else
 		if(signal(SIGINT, sighandler) == SIG_ERR) {
 			fprintf(stderr, "Failed to install signal handler for ^C.\n");
 			exit(1);
 		}
-	}
 #endif
+	}
 }
 
 void term_cleanup() {
@@ -395,7 +429,8 @@ int term_handles_wrapping() {
 
 static void suspend() {
 	tty_restore();
-#ifndef _WIN32
+#ifdef _WIN32
+#else
 	kill(0, SIGSTOP);
 #endif
 	tty_setup();

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -446,6 +446,7 @@ int term_getkey(const char *prompt) {
 	fflush(stdout);
 
 	if(NEVER_A_TTY || !isatty(0)) {
+		unread_lines = 0; // Usually doesn't matter if !isatty(0) but does on Windows
 		ch = fgetc(stdin);
 		return (ch == EOF)? -1 : ch;
 	}
@@ -497,6 +498,7 @@ int term_getline(const char *prompt, uint8_t *buffer, int bufsize, int is_filena
 	fflush(stdout);
 
 	if(NEVER_A_TTY || !isatty(0)) {
+		unread_lines = 0; // Usually doesn't matter if !isatty(0) but does on Windows
 		if(fgets((char *) buffer, bufsize, stdin)) {
 			len = strlen((char *) buffer);
 			if(len && buffer[len - 1] == '\n') buffer[--len] = 0;

--- a/src/term_tty.c
+++ b/src/term_tty.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #ifdef _WIN32
 	#include <windows.h>
-	#define NEVER_A_TTY 1 // Windows doesn't support messing with line echoing, so we let the shell handle history and line editing by pretending it's not a TTY
+	#define NEVER_A_TTY 1 // Windows doesn't support messing with line echoing, so we let the terminal handle history and line editing by telling dgdebug that it's not a TTY
 #else
 	#include <sys/ioctl.h>
 	#include <termios.h>
@@ -79,6 +79,7 @@ void tty_restore() {
 #endif
 }
 
+// This function is called periodically during processing. It's part of the API specifically for the Glk version, where control has to be handed over to Glk to update the graphics and such. But it turns out to be convenient for us here too now: this function will be called in the main thread, while interrupt handlers (on Windows specifically) will not be.
 void term_ticker() {
 #ifdef _WIN32
 	if(interrupt_flag) {
@@ -384,6 +385,7 @@ void term_init(term_int_callback_t callback) {
 	term_int_callback = callback;
 	if(isatty(0)) {
 #ifdef _WIN32
+		// https://stackoverflow.com/a/16826362/3233017
 		if(!SetConsoleCtrlHandler((PHANDLER_ROUTINE)sighandler, TRUE)) {
 			fprintf(stderr, "Failed to install signal handler for ^C.\n");
 			exit(1);


### PR DESCRIPTION
dgdebug_tty.exe started out as an extremely basic stopgap to make dgt work on Windows. But it's actually taken surprisingly little work to turn it into a functional program in its own right. This branch is an experiment toward that end. If it can achieve basically the same functionality as dgdebug on Mac and Linux, then we can deprecate the (generally buggier and less-featureful) Windows Glk frontend.

Things the Windows TTY implementation still lacks:

- [x] Turn off input echoing, which is necessary for the history implementation—but it sounds like the shell can do that for us
- [x] Ctrl-C to interrupt an infinite loop (i.e. while processing is happening)
- [x] Ctrl-C to interrupt a flood of output (i.e. at the [more] prompt)
- [x] Terminal size measuring so explicit --width and --height don't have to be put in
- [x] Formatting with ANSI escapes
- [x] Compatibility with pipes for dgt usage

Once we've got all of these, I'll feel comfortable making it the official dgdebug.exe for the future.