### PR TITLE
Bump version to 1b/02-dev

### DIFF
--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -1,6 +1,6 @@
 name: dialog
 title: Dialog
-version: 1b01
+version: 1b02-dev
 nav:
   - modules/ROOT/nav.adoc
   - modules/lang/nav.adoc

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-DIALOG_VERSION=1b/01
+DIALOG_VERSION=1b/02-dev
 
 CC		= gcc
 CFLAGS		+= -O3 -Wall -Wno-unused-result -Wno-format-truncation -DVERSION=\"${DIALOG_VERSION}\"


### PR DESCRIPTION
Antora requires main to have a different version number than any release before the manual can be built.