### PR TITLE
redesign unit.dg to eliminate (list of tests $)

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1428,7 +1428,7 @@ int debugger(int argc, char **argv) {
 			case 'T':
 				io_tag_lines = 1;
 				break;
-			case 'u': // --no-warn-not-topic --quit --height=-1
+			case 'u': // --quit --no-header --height=-1
 				quitopt = 1;
 				force_height = -1;
 				suppress_header = 1;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1332,8 +1332,7 @@ void usage(char *prgname) {
 	fprintf(stderr, "--numbered  -N      Show call depth with numbers during tracing.\n");
 	fprintf(stderr, "--tag-lines -T      Prepend output with \"  \", input with \"> \" or \") \".\n");
 	fprintf(stderr, "--no-header         Don't show version information at startup.\n");
-	fprintf(stderr, "--unit-test -u      Same as --no-warn-not-topic --quit --height=-1\n");
-	fprintf(stderr, "                    --no-header.\n");
+	fprintf(stderr, "--unit-test -u      Same as --quit --height=-1 --no-header.\n");
 }
 
 extern int topic_warning_level; // Defined in frontend.c
@@ -1430,7 +1429,6 @@ int debugger(int argc, char **argv) {
 				io_tag_lines = 1;
 				break;
 			case 'u': // --no-warn-not-topic --quit --height=-1
-				topic_warning_level = 2;
 				quitopt = 1;
 				force_height = -1;
 				suppress_header = 1;

--- a/test/unit/fail-1.dg
+++ b/test/unit/fail-1.dg
@@ -1,8 +1,5 @@
 %% dgdebug -u fail-1.dg unit.dg stdlib.dg
 
-(list of tests [
-	#intentionally-fail-this-test
-	])
-
-(test #intentionally-fail-this-test)
-	  (fail)
+#intentionally-fail-this-test
+(test *)
+(run *)	(fail)

--- a/test/unit/fatal-error.dg
+++ b/test/unit/fatal-error.dg
@@ -1,9 +1,8 @@
 %% dgdebug -u fatal-error.dg unit.dg stdlib.dg
 
-(list of tests [#bottles-of-beer])
-
 (bottles of beer $Bottles)
 	  (bottles of beer $Bottles) %% overflow the heap
 
-(test #bottles-of-beer)
-	  (bottles of beer 16383)
+#bottles-of-beer
+(test *)
+(run *)	(bottles of beer 16383)

--- a/test/unit/pass-1.dg
+++ b/test/unit/pass-1.dg
@@ -1,7 +1,5 @@
 %% dgdebug -u pass-1.dg unit.dg stdlib.dg
 
-(list of tests [
-	#pass-this-test
-	])
-
-(test #pass-this-test)
+#pass-this-test
+(test *)
+(run *)

--- a/test/unit/time-tests.dg
+++ b/test/unit/time-tests.dg
@@ -606,34 +606,3 @@
 	(now) (time rate 2)
 	(tick)
 	(15 hours 3 minutes)
-
-#suspend-tick
-(test *)
-(run *)
-	(now) (suspend this tick)
-	(tick)
-	(14 hours 51 minutes)
-	~(suspend this tick)
-	(tick)
-	(14 hours 52 minutes)
-
-#stop-time
-(test *)
-(run *)
-	(now) ~(time is running)
-	~(suspend this tick)
-	(tick)
-	(14 hours 51 minutes)
-	(tick)
-	(14 hours 51 minutes)
-
-#restart-time
-(test *)
-(run *)
-	(now) ~(time is running)
-	(14 hours 51 minutes)
-	(tick)
-	(14 hours 51 minutes)
-	(now) (time is running)
-	(tick)
-	(14 hours 52 minutes)

--- a/test/unit/time-tests.dg
+++ b/test/unit/time-tests.dg
@@ -4,483 +4,588 @@
 %% By convention, the top line of the test file specifies the command
 %% line to run it, including any dependencies.
 
-(list of tests [
-	#hours-minutes
-	#hours-minutes-assert
-	#day-month-year
-	#1969-is-not-a-leap-year
-	#1980-is-a-leap-year
-	#2000-is-a-leap-year
-	#2100-is-not-a-leap-year
-	#2400-is-a-leap-year
-	#jan-1969-has-31
-	#feb-1969-has-28
-	#feb-1980-has-29
-	#feb-2000-has-29
-	#feb-2100-has-28
-	#feb-2400-has-29
-	#length-of-1969-is-365
-	#length-of-1980-is-366
-	#length-of-2000-is-366
-	#length-of-2100-is-365
-	#length-of-2400-is-366
-	#12-is-jan-12-1969
-	#55-is-feb-24-1966
-	#83-is-mar-24-1999
-	#84-is-mar-24-2000
-	#365-is-dec-31-1999
-	#366-is-dec-31-2000
-	#367-is-invalid
-	#366-of-non-leap-year-is-invalid
-	#jan-12-1969-is-12
-	#feb-24-1966-is-55
-	#mar-24-1999-is-83
-	#mar-24-2000-is-84
-	#dec-31-1999-is-365
-	#dec-31-2000-is-366
-	#january-1801-starts-with-thursday
-	#january-1901-starts-with-tuesday
-	#january-2001-starts-with-monday
-	#january-2101-starts-with-saturday
-	#january-2201-starts-with-thursday
-	#january-2301-starts-with-tuesday
-	#january-1969-starts-with-wednesday
-	#january-1999-starts-with-friday
-	#january-1753-starts-with-monday
-	#tick-tock
-	#leading-zero-zero
-	#leading-zero-one
-	#leading-zero-nine
-	#leading-zero-ten
-	#clock-time
-	#clock-time-midnight
-	#clock-time-noon
-	#clock-time-morning
-	#clock-time-afternoon
-	#military-time
-	#military-time-midnight
-	#military-time-noon
-	#military-time-morning
-	#military-time-afternoon
-	#nato-time
-	#nato-time-union
-	#short-date
-	#short-date-eu
-	#full-date
-	#full-date-eu
-	#full-date-weekday
-	#full-date-weekday-eu
-	#full-date-union
-	#set-time
-	#set-time-only
-	#set-date
-	#elapse-0-minutes
-	#elapse-8-minutes
-	#elapse-9-minutes
-	#elapse-60-minutes
-	#elapse-360-minutes
-	#elapse-past-midnight
-	#elapse-multiple-days
-	#elapse-16383-minutes
-	#elapse-0-hours
-	#elapse-4-hours
-	#elapse-23-hours
-	#elapse-25-hours
-	#elapse-16383-hours
-	#elapse-0-days
-	#elapse-3-days
-	#elapse-11-days
-	#elapse-12-days
-	#elapse-23-days
-	#elapse-16017-days
-	#dont-elapse-16383-days
-	#elapse-0-months
-	#elapse-2-months
-	#elapse-past-highest-date
-	#elapse-18-months
-	#elapse-16371-months
-	#dont-elapse-16383-months
-	#elapse-0-years
-	#elapse-2-years
-	#elapse-200-years
-	#elapse-2000-years
-	#elapse-14414-years
-	#dont-elapse-16383-years
-	#suspend-tick
-	#stop-time
-	#restart-time
-	])
-
 (current datetime [891 12 1969])
 
 (january starts on 3) %% Wednesday
 
 (clean up $)	(set time [891 12 1969])
+	   	  		(now) (january starts on 3)
 		  		(now) (using north american dates)
 				(now) (time is running)
 				(now) ~(suspend next tick)
+				(now) (time rate 1)
 
-%%----------------------------------------------------------------------
-
-%% It's more succinct to just use the values you're asserting on directly,
-%% and let binding fail if the test fails, but if you want to be more
-%% explicit, or want to check the output to find out what's going on, you
-%% can follow a pattern like this.
-%% You can use (log) or not as you prefer; since we're just running this
-%% in dgdebug and throwing away the output, regular printing is fine.
-(test #hours-minutes-assert)
+#hours-minutes-assert
+(test *)
+(run *)
 	($Hours hours $Minutes minutes)
 	$Hours $Minutes
 	(assert $Hours = 14)
 	(assert $Minutes = 51)
 
 %% Here's a more succinct formulation of the above.
-(test #hours-minutes)
+#hours-minutes
+(test *)
+(run *)
 	(14 hours 51 minutes)
 
-(test #day-month-year)
+#day-month-year
+(test *)
+(run *)
 	(day 12 month 1 year 1969)
 
-(test #1969-is-not-a-leap-year)
+#1969-is-not-a-leap-year
+(test *)
+(run *)
 	~(1969 is a leap year)
 
-(test #1980-is-a-leap-year)
+#1980-is-a-leap-year
+(test *)
+(run *)
 	(1980 is a leap year)
 
-(test #2000-is-a-leap-year)
+#2000-is-a-leap-year
+(test *)
+(run *)
 	(2000 is a leap year)
 
-(test #2100-is-not-a-leap-year)
+#2100-is-not-a-leap-year
+(test *)
+(run *)
 	~(2100 is a leap year)
 
-(test #2400-is-a-leap-year)
+#2400-is-a-leap-year
+(test *)
+(run *)
 	(2400 is a leap year)
 
-(test #jan-1969-has-31)
+#jan-1969-has-31
+(test *)
+(run *)
 	(days in 1 into 31 for 1969)
 
-(test #feb-1969-has-28)
+#feb-1969-has-28
+(test *)
+(run *)
 	(days in 2 into 28 for 1969)
 
-(test #feb-1980-has-29)
+#feb-1980-has-29
+(test *)
+(run *)
 	(days in 2 into 29 for 1980)
 
-(test #feb-2000-has-29)
+#feb-2000-has-29
+(test *)
+(run *)
 	(days in 2 into 29 for 2000)
 
-(test #feb-2100-has-28)
+#feb-2100-has-28
+(test *)
+(run *)
 	(days in 2 into 28 for 2100)
 
-(test #feb-2400-has-29)
+#feb-2400-has-29
+(test *)
+(run *)
 	(days in 2 into 29 for 2400)
 
-(test #length-of-1969-is-365)
+#length-of-1969-is-365
+(test *)
+(run *)
 	(length of year 1969 into 365)
 
-(test #length-of-1980-is-366)
+#length-of-1980-is-366
+(test *)
+(run *)
 	(length of year 1980 into 366)
 
-(test #length-of-2000-is-366)
+#length-of-2000-is-366
+(test *)
+(run *)
 	(length of year 2000 into 366)
 
-(test #length-of-2100-is-365)
+#length-of-2100-is-365
+(test *)
+(run *)
 	(length of year 2100 into 365)
 
-(test #length-of-2400-is-366)
+#length-of-2400-is-366
+(test *)
+(run *)
 	(length of year 2400 into 366)
 
-(test #12-is-jan-12-1969)
+#12-is-jan-12-1969
+(test *)
+(run *)
 	(day 12 of 1969 is 1 12)
 
-(test #55-is-feb-24-1966)
+#55-is-feb-24-1966
+(test *)
+(run *)
 	(day 55 of 1966 is 2 24)
 
-(test #83-is-mar-24-1999)
+#83-is-mar-24-1999
+(test *)
+(run *)
 	(day 83 of 1999 is 3 24)
 
-(test #84-is-mar-24-2000)
+#84-is-mar-24-2000
+(test *)
+(run *)
 	(day 84 of 2000 is 3 24)
 
-(test #365-is-dec-31-1999)
+#365-is-dec-31-1999
+(test *)
+(run *)
 	(day 365 of 1999 is 12 31)
 
-(test #366-is-dec-31-2000)
+#366-is-dec-31-2000
+(test *)
+(run *)
 	(day 366 of 2000 is 12 31)
 
-(test #367-is-invalid)
+#367-is-invalid
+(test *)
+(run *)
 	~(day 367 of 2028 is $ $)
 
-(test #366-of-non-leap-year-is-invalid)
+#366-of-non-leap-year-is-invalid
+(test *)
+(run *)
 	~(day 366 of 1999 is $ $)
 
-(test #jan-12-1969-is-12)
+#jan-12-1969-is-12
+(test *)
+(run *)
 	(1 12 is day 12 of 1969)
 
-(test #feb-24-1966-is-55)
+#feb-24-1966-is-55
+(test *)
+(run *)
 	(2 24 is day 55 of 1966)
 
-(test #mar-24-1999-is-83)
+#mar-24-1999-is-83
+(test *)
+(run *)
 	(3 24 is day 83 of 1999)
 
-(test #mar-24-2000-is-84)
+#mar-24-2000-is-84
+(test *)
+(run *)
 	(3 24 is day 84 of 2000)
 
-(test #dec-31-1999-is-365)
+#dec-31-1999-is-365
+(test *)
+(run *)
 	(12 31 is day 365 of 1999)
 
-(test #dec-31-2000-is-366)
+#dec-31-2000-is-366
+(test *)
+(run *)
 	(12 31 is day 366 of 2000)
 
-(test #january-1801-starts-with-thursday)
+#january-1801-starts-with-thursday
+(test *)
+(run *)
 	(january 1801 starts on 4)
 
-(test #january-1901-starts-with-tuesday)
+#january-1901-starts-with-tuesday
+(test *)
+(run *)
 	(january 1901 starts on 2)
 
-(test #january-2001-starts-with-monday)
+#january-2001-starts-with-monday
+(test *)
+(run *)
 	(january 2001 starts on 1)
 
-(test #january-2101-starts-with-saturday)
+#january-2101-starts-with-saturday
+(test *)
+(run *)
 	(january 2101 starts on 6)
 
-(test #january-2201-starts-with-thursday)
+#january-2201-starts-with-thursday
+(test *)
+(run *)
 	(january 2201 starts on 4)
 
-(test #january-2301-starts-with-tuesday)
+#january-2301-starts-with-tuesday
+(test *)
+(run *)
 	(january 2301 starts on 2)
 
-(test #january-1969-starts-with-wednesday)
+#january-1969-starts-with-wednesday
+(test *)
+(run *)
 	(january 1969 starts on 3)
 
-(test #january-1999-starts-with-friday)
+#january-1999-starts-with-friday
+(test *)
+(run *)
 	(january 1999 starts on 5)
 
-(test #january-1753-starts-with-monday)
+#january-1753-starts-with-monday
+(test *)
+(run *)
 	(january 1753 starts on 1)
 
-(test #leading-zero-zero)
+#leading-zero-zero
+(test *)
+(run *)
 	(collect words) (leading zero 0) (into [0 0])
 
-(test #leading-zero-one)
+#leading-zero-one
+(test *)
+(run *)
 	(collect words) (leading zero 1) (into [0 1])
 
-(test #leading-zero-nine)
+#leading-zero-nine
+(test *)
+(run *)
 	(collect words) (leading zero 9) (into [0 9])
 
-(test #leading-zero-ten)
+#leading-zero-ten
+(test *)
+(run *)
 	(collect words) (leading zero 10) (into [10])
 
-(test #clock-time)
+#clock-time
+(test *)
+(run *)
 	(collect words) (clock time) (into [2 : 51 pm])
 
-(test #clock-time-midnight)
+#clock-time-midnight
+(test *)
+(run *)
 	(collect words) (clock time for 0) (into [12 : 0 0 am])
 
-(test #clock-time-noon)
+#clock-time-noon
+(test *)
+(run *)
 	(collect words) (clock time for 720) (into [12 : 0 0 pm])
 
-(test #clock-time-morning)
+#clock-time-morning
+(test *)
+(run *)
 	(collect words) (clock time for 390) (into [6 : 30 am])
 
-(test #clock-time-afternoon)
+#clock-time-afternoon
+(test *)
+(run *)
 	(collect words) (clock time for 980) (into [4 : 20 pm])
 
-(test #military-time)
+#military-time
+(test *)
+(run *)
 	(collect words) (military time) (into [14 : 51])
 
-(test #military-time-midnight)
+#military-time-midnight
+(test *)
+(run *)
 	(collect words) (military time for 0) (into [0 0 : 0 0])
 
-(test #military-time-noon)
+#military-time-noon
+(test *)
+(run *)
 	(collect words) (military time for 720) (into [12 : 0 0])
 
-(test #military-time-morning)
+#military-time-morning
+(test *)
+(run *)
 	(collect words) (military time for 390) (into [0 6 : 30])
 
-(test #military-time-afternoon)
+#military-time-afternoon
+(test *)
+(run *)
 	(collect words) (military time for 980) (into [16 : 20])
 
-(test #nato-time)
+#nato-time
+(test *)
+(run *)
 	(collect words) (nato time) (into [12 14 51 Z jan 69])
 
-(test #nato-time-union)
+#nato-time-union
+(test *)
+(run *)
 	(set time [750 64 2273])
 	(collect words) (nato time) (into [0 5 12 30 Z mar 73])
 
-(test #short-date)
+#short-date
+(test *)
+(run *)
 	(collect words) (short date) (into [1 \/ 12 \/ 1969])
 
-(test #short-date-eu)
+#short-date-eu
+(test *)
+(run *)
 	(now) ~(using north american dates)
 	(collect words) (short date) (into [12 - 1 - 1969])
 
-(test #full-date)
+#full-date
+(test *)
+(run *)
 	(collect words) (full date) (into [January 12 , 1969])
 
-(test #full-date-eu)
+#full-date-eu
+(test *)
+(run *)
 	(now) ~(using north american dates)
 	(collect words) (full date) (into [12 January , 1969])
 
-(test #full-date-weekday)
+#full-date-weekday
+(test *)
+(run *)
 	(collect words) (full date with weekday) (into [Sunday , January 12 , 1969])
 
-(test #full-date-weekday-eu)
+#full-date-weekday-eu
+(test *)
+(run *)
 	(now) ~(using north american dates)
 	(collect words) (full date with weekday) (into [Sunday , 12 January , 1969])
 
-(test #full-date-union)
+#full-date-union
+(test *)
+(run *)
 	(set time [750 64 2273])
 	(collect words) (full date with weekday) (into [Wednesday , March 5 , 2273])
 
-(test #set-time)
+#normalize-pathological
+(test *)
+(run *)
+	(set time [16383 16372 2026])
+	(current datetime [543 312 2070])
+
+#set-time
+(test *)
+(run *)
 	(set time [430 12 1969])
 	(7 hours 10 minutes)
 
-(test #set-time-only)
+#set-time-only
+(test *)
+(run *)
 	(set time 7 10)
 	(7 hours 10 minutes)
 	(current datetime [430 12 1969])
 
-(test #set-date)
+#set-date
+(test *)
+(run *)
 	(set date 24 3 2000)
 	(current datetime [891 84 2000])
 
-(test #elapse-0-minutes)
+#elapse-0-minutes
+(test *)
+(run *)
 	(elapse 0 minutes)
 	(14 hours 51 minutes)
 
-(test #elapse-8-minutes)
+#elapse-8-minutes
+(test *)
+(run *)
 	(elapse 8 minutes)
 	(14 hours 59 minutes)
 
-(test #elapse-9-minutes)
+#elapse-9-minutes
+(test *)
+(run *)
 	(elapse 9 minutes)
 	(15 hours 0 minutes)
 
-(test #elapse-60-minutes)
+#elapse-60-minutes
+(test *)
+(run *)
 	(elapse 60 minutes)
 	(15 hours 51 minutes)
 
-(test #elapse-360-minutes)
+#elapse-360-minutes
+(test *)
+(run *)
 	(elapse 360 minutes)
 	(20 hours 51 minutes)
 
-(test #elapse-past-midnight)
+#elapse-past-midnight
+(test *)
+(run *)
 	(elapse 1339 minutes)
 	(13 hours 10 minutes)
 
-(test #elapse-multiple-days)
+#elapse-multiple-days
+(test *)
+(run *)
 	(elapse 4320 minutes)
 	(14 hours 51 minutes)
 
-(test #elapse-16383-minutes)
+#elapse-16383-minutes
+(test *)
+(run *)
 	(elapse 16383 minutes)
 	(current datetime [1434 23 1969])
 
-(test #elapse-0-hours)
+#elapse-0-hours
+(test *)
+(run *)
 	(elapse 0 hours)
 	(14 hours 51 minutes)
 
-(test #elapse-4-hours)
+#elapse-4-hours
+(test *)
+(run *)
 	(elapse 4 hours)
 	(18 hours 51 minutes)
 
-(test #elapse-23-hours)
+#elapse-23-hours
+(test *)
+(run *)
 	(elapse 23 hours)
 	(current datetime [831 13 1969])
 
-(test #elapse-25-hours)
+#elapse-25-hours
+(test *)
+(run *)
 	(elapse 25 hours)
 	(current datetime [951 13 1969])
 
-(test #elapse-16383-hours)
+#elapse-16383-hours
+(test *)
+(run *)
 	(elapse 16383 hours)
 	(current datetime [351 330 1970])
 
-(test #elapse-0-days)
+#elapse-0-days
+(test *)
+(run *)
 	(elapse 0 days)
 	(current datetime [891 12 1969])
 
-(test #elapse-3-days)
+#elapse-3-days
+(test *)
+(run *)
 	(elapse 3 days)
 	(current datetime [891 15 1969])
 
-(test #elapse-11-days)
+#elapse-11-days
+(test *)
+(run *)
 	(elapse 11 days)
 	(current datetime [891 23 1969])
 
-(test #elapse-12-days)
+#elapse-12-days
+(test *)
+(run *)
 	(elapse 12 days)
 	(current datetime [891 24 1969])
 
-(test #elapse-23-days)
+#elapse-23-days
+(test *)
+(run *)
 	(elapse 23 days)
 	(current datetime [891 35 1969])
 
-(test #elapse-365-days)
+#elapse-365-days
+(test *)
+(run *)
 	(elapse 365 days)
 	(current datetime [891 12 1970])
 
-(test #elapse-16017-days)
+#elapse-16017-days
+(test *)
+(run *)
 	(elapse 16017 days)
 	(current datetime [891 324 2012])
 
-(test #dont-elapse-16383-days)
+#dont-elapse-16383-days
+(test *)
+(run *)
 	~(elapse 16383 days)
 
-(test #elapse-0-months)
+#elapse-0-months
+(test *)
+(run *)
 	(elapse 0 months)
 	(day 12 month 1 year 1969)
 
-(test #elapse-2-months)
+#elapse-2-months
+(test *)
+(run *)
 	(elapse 2 months)
 	(day 12 month 3 year 1969)
 
-(test #elapse-past-highest-date)
+#elapse-past-highest-date
+(test *)
+(run *)
 	(elapse 19 days)  %% to January 31
 	(elapse 1 months) %% to February 31 => March 3
 	(day 3 month 3 year 1969)
 
-(test #elapse-8-months-overflow)
+#elapse-8-months-overflow
+(test *)
+(run *)
 	(set date 1 6 1970)
 	(elapse 8 months)
 	(day 1 month 2 year 1971)
 
-(test #elapse-18-months)
+#elapse-18-months
+(test *)
+(run *)
 	(elapse 18 months)
 	(day 12 month 7 year 1970)
 
-(test #elapse-16371-months)
+#elapse-16371-months
+(test *)
+(run *)
 	(elapse 16371 months)
 	(current datetime [891 102 3333])
 
-(test #dont-elapse-16383-months)
+#dont-elapse-16383-months
+(test *)
+(run *)
 	~(elapse 16383 months)
 
-(test #elapse-0-years)
+#elapse-0-years
+(test *)
+(run *)
 	(elapse 0 years)
 	(current datetime [891 12 1969])
 
-(test #elapse-2-years)
+#elapse-2-years
+(test *)
+(run *)
 	(elapse 2 years)
 	(current datetime [891 12 1971])
 
-(test #elapse-200-years)
+#elapse-57-years
+(test *)
+(run *)
+	(elapse 57 years)
+	(current datetime [891 12 2026])
+
+#elapse-200-years
+(test *)
+(run *)
 	(elapse 200 years)
 	(current datetime [891 12 2169])
 
-(test #elapse-2000-years)
+#elapse-2000-years
+(test *)
+(run *)
 	(elapse 2000 years)
 	(current datetime [891 12 3969])
 
-(test #elapse-14414-years)
+#elapse-14414-years
+(test *)
+(run *)
 	(elapse 14414 years)
 	(current datetime [891 12 16383])
 
-(test #dont-elapse-16383-years)
+#dont-elapse-16383-years
+(test *)
+(run *)
 	~(elapse 16383 years)
 
-(test #tick-tock)
+#tick-tock
+(test *)
+(run *)
 	(time is running)
 	~(suspend this tick)
 	(tick)
@@ -488,7 +593,23 @@
 	(tick)
 	(14 hours 53 minutes)
 
-(test #suspend-tick)
+#time-rate
+(test *)
+(run *)
+	(now) (time rate 5)
+	(time is running)
+	~(suspend this tick)
+	(tick)
+	(14 hours 56 minutes)
+	(tick)
+	(15 hours 1 minutes)
+	(now) (time rate 2)
+	(tick)
+	(15 hours 3 minutes)
+
+#suspend-tick
+(test *)
+(run *)
 	(now) (suspend this tick)
 	(tick)
 	(14 hours 51 minutes)
@@ -496,7 +617,9 @@
 	(tick)
 	(14 hours 52 minutes)
 
-(test #stop-time)
+#stop-time
+(test *)
+(run *)
 	(now) ~(time is running)
 	~(suspend this tick)
 	(tick)
@@ -504,7 +627,9 @@
 	(tick)
 	(14 hours 51 minutes)
 
-(test #restart-time)
+#restart-time
+(test *)
+(run *)
 	(now) ~(time is running)
 	(14 hours 51 minutes)
 	(tick)

--- a/test/unit/time.dg
+++ b/test/unit/time.dg
@@ -29,9 +29,6 @@
 %% negate to stop time from advancing on every tick
 (time is running)
 
-%% un-negate to not advance time on the next tick ("free" command)
-~(suspend this tick)
-
 %%-------------------------------- INTERFACES --------------------------------
 
 (interface (set time $<Time))
@@ -376,8 +373,7 @@
 	(set time [$Time $Day $Year])
 
 (late on every tick)
-	(if) (time is running) ~(suspend this tick) (then)
+	(if) (time is running) (then)
 		 (time rate $Rate)
 		 (elapse $Rate minutes)
 	(endif)
-	(now) ~(suspend this tick)

--- a/test/unit/time.dg
+++ b/test/unit/time.dg
@@ -18,6 +18,22 @@
 
 (global variable (january starts on $)) %% day of week on New Year's day
 
+(global variable (time rate 1)) %% default number of minutes per move
+
+%% negate to get D-M-Y dates
+(using north american dates)
+
+%% override for a different time zone
+(timezone letter)	Z
+
+%% negate to stop time from advancing on every tick
+(time is running)
+
+%% un-negate to not advance time on the next tick ("free" command)
+~(suspend this tick)
+
+%%-------------------------------- INTERFACES --------------------------------
+
 (interface (set time $<Time))
 
 (interface (set time $<Hour $<Minute))
@@ -62,19 +78,7 @@
 
 (interface (elapse $<Num years))
 
-%% negate to get D-M-Y dates
-(using north american dates)
-
-%% override for a different time zone
-(timezone letter)	Z
-
-%% negate to stop time from advancing on every tick
-(time is running)
-
-%% un-negate to not advance time on the next tick ("free" command)
-~(suspend this tick)
-
-%%----------------------------------------------------------------------
+%%------------------------------ IMPLEMENTATION ------------------------------
 
 ($Hours hours $Minutes minutes for $Time)
 	($Time divided by 60 into $Hours)
@@ -293,7 +297,7 @@
 
 (normalize $Timestamp into $NewTimestamp)
 	([$Time $Date $Year] = $Timestamp)
-	(if) ($Time > 1440) (then)
+	(if) ($Time > 1439) (then)
 		($Time divided by 1440 into $Days)
 		($Time modulo 1440 into $NewTime)
 		($Date plus $Days into $NewDate)
@@ -364,30 +368,16 @@
 	(elapse $Minutes minutes)
 
 (elapse $Num minutes)
-	(current datetime [$T $D $Y])
+	(current datetime [$T $D $Year])
 	($Num divided by 1440 into $Days)
 	($Num modulo 1440 into $Minutes)
-	($D plus $Days into $Date)
-	($T plus $Minutes into $Ticks)
-	(if) ($Ticks > 1439) (then)
-		($Ticks minus 1440 into $Time)
-		($Date plus 1 into $ND)
-	(else)
-		($Time = $Ticks)
-		($ND = $Date)
-	(endif)
-	(length of year $Y into $Length)
-	(if) ($ND > $Length) (then)
-		($Y plus 1 into $Year)
-		($ND modulo $Length into $Day)
-	(else)
-		($Y = $Year)
-		($ND = $Day)
-	(endif)
+	($D plus $Days into $Day)
+	($T plus $Minutes into $Time)
 	(set time [$Time $Day $Year])
 
 (late on every tick)
 	(if) (time is running) ~(suspend this tick) (then)
-		 (elapse 1 minutes)
+		 (time rate $Rate)
+		 (elapse $Rate minutes)
 	(endif)
 	(now) ~(suspend this tick)

--- a/test/unit/utils-tests.dg
+++ b/test/unit/utils-tests.dg
@@ -1,111 +1,5 @@
 %% dgdebug -u utils-tests.dg utils.dg unit.dg stdlib.dg
 
-(list of tests [
-	#max-different
-	#max-same
-	#min-different
-	#min-same
-	#0-isnt-odd-or-even
-	#1-is-odd
-	#2-is-even
-	#3-is-odd
-	#delta-4-2
-	#delta-2-4
-	#delta-2-2
-	#delta-0-0
-	#range-5-3
-	#range-3-5
-	#range-3-3
-	#range-0-3
-	#range-0-0
-	#intentionally-fail-this-test
-	#3-div-3-rounding-up
-	#4-div-3-rounding-up
-	#5-div-3-rounding-up
-	#6-div-3-rounding-up
-	#10-plus-20
-	#10-plus-20-max-25
-	#8192-plus-8191-max-16380
-	#8192-plus-8192-max-16380
-	#16380-plus-3
-	#16380-plus-4
-	#30-minus-20
-	#30-minus-40
-	#split-number
-	#split-smaller
-	#split-smallest
-	#sort-4-2
-	#sort-2-4
-	#sort-0-0
-	#sort-1-2-3
-	#sort-1-3-2
-	#sort-2-3-1
-	#sort-2-1-3
-	#sort-3-2-1
-	#sort-3-1-2
-	#take-last-n
-	#take-last-zero
-	#take-last-more-than-len
-	#also-intentionally-fail-this-one
-	#replace-element
-	#replace-element-zero
-	#replace-element-beyond-end
-	#replace-element-with-max
-	#replace-element-beyond-max
-	#increase-element
-	#increase-element-zero
-	#increase-element-beyond-end
-	#increase-element-with-max
-	#increase-element-beyond-max
-	#decrease-element
-	#decrease-element-below-zero
-	#decrease-element-zero
-	#decrease-element-beyond-end
-	#match-one-of-the-key
-	#match-three-of-the-key
-	#match-zero-of-the-key
-	#dont-match-element-0
-	#dont-match-element-beyond-end
-	#match-not-one-of-the-key
-	#match-not-three-of-the-key
-	#match-not-zero-of-the-key
-	#adding-to-the-list-but-not-writing-a-test-makes-it-intentionally-fail
-	#12345-begins-with-12
-	#12345-begins-with-12345
-	#12345-doesnt-begin-with-22
-	#12345-doesnt-begin-with-123456
-	#12345-doesnt-begin-with-scalar
-	#12345-doesnt-begin-with-nested
-	#find-12
-	#find-22
-	#dont-find-99
-	#dont-find-123456
-	#dont-find-scalar
-	#dont-find-in-empty-list
-	#set-1-in-1-to-2
-	#set-1-in-2-to-2
-	#set-2-in-22-to-3
-	#set-2-in-22-to-4
-	#set-4-in-12345-to-6
-	#set-4-in-32456-to-7
-	#dont-set-6-in-12345
-	#dont-set-0-in-12345
-	#find-type-and-id
-	#dont-find-type-and-id
-	#remove-1-2
-	#remove-2-2
-	#remove-3-2
-	#remove-4-1
-	#remove-7-7
-	#remove-1-2-twice
-	#remove-3-2-twice
-	#remove-in-filter
-	#remove-multiple-match
-	#remove-in-empty-filter
-	#remove-empty-list-in-filter
-	#remove-in-disjoint-filter
-	])
-
 (global variable (list of lists [
 	[1 2 3 4 5]
 	[2 2 4 5 6]
@@ -113,204 +7,338 @@
 	[3 2 4 6 7]
 	[4 1 7 8 9]]))
 
-%%-----------------------------------------------------------------------------
-
-(test #max-different)
-	(max 2 and 3 into 3)
-	(max 3 and 2 into 3)
-
-(test #max-same)
-	(max 2 and 2 into 2)
-
-(test #min-different)
-	(min 2 and 3 into 2)
-	(min 3 and 2 into 2)
-
-(test #min-same)
-	(min 2 and 2 into 2)
-
-(test #0-isnt-odd-or-even)
+#0-isnt-odd-or-even
+(test *)
+(run *)
     ~(0 is odd)
 	~(0 is even)
 
-(test #1-is-odd)
+#1-is-odd
+(test *)
+(run *)
     (1 is odd)
 	~(1 is even)
 
-(test #2-is-even)
+#2-is-even
+(test *)
+(run *)
     ~(2 is odd)
 	(2 is even)
 
-(test #3-is-odd)
+#3-is-odd
+(test *)
+(run *)
     (3 is odd)
 	~(3 is even)
 
-(test #delta-4-2)
-	(4 delta 2 into 2)
+#max-different
+(test *)
+(run *)
+	(max 2 and 3 into 3)
+	(max 3 and 2 into 3)
 
-(test #delta-2-4)
-	(2 delta 4 into 2)
+#max-same
+(test *)
+(run *)
+	(max 2 and 2 into 2)
 
-(test #delta-2-2)
-	(2 delta 2 into 0)
+#min-different
+(test *)
+(run *)
+	(min 2 and 3 into 2)
+	(min 3 and 2 into 2)
 
-(test #delta-0-0)
-	(0 delta 0 into 0)
+#min-same
+(test *)
+(run *)	(min 2 and 2 into 2)
 
-(test #range-5-3)
-	(5 is within 2 of 3)
+#round-0-0
+(test *)
+(run *)	(round 0 to the nearest 5 into 0)
 
-(test #range-3-5)
-	(3 is within 2 of 5)
+#round-1-0
+(test *)
+(run *)	(round 1 to the nearest 5 into 0)
 
-(test #range-3-3)
-	(3 is within 0 of 3)
+#round-2-0
+(test *)
+(run *)	(round 2 to the nearest 5 into 0)
 
-(test #range-0-3)
-	(0 is within 3 of 3)
+#round-3-5
+(test *)
+(run *)	(round 3 to the nearest 5 into 5)
 
-(test #range-0-0)
-	(0 is within 0 of 0)
+#round-4-5
+(test *)
+(run *)	(round 4 to the nearest 5 into 5)
 
-(test #3-div-3-rounding-up)
-	(3 divided by 3 into 1 rounding up)
+#round-5-5
+(test *)
+(run *)	(round 5 to the nearest 5 into 5)
 
-(test #4-div-3-rounding-up)
-	(4 divided by 3 into 2 rounding up)
+#round-7-5
+(test *)
+(run *)	(round 7 to the nearest 5 into 5)
 
-(test #5-div-3-rounding-up)
-	(5 divided by 3 into 2 rounding up)
+#round-8-10
+(test *)
+(run *)	(round 8 to the nearest 5 into 10)
 
-(test #6-div-3-rounding-up)
-	(6 divided by 3 into 2 rounding up)
+#round-4-0
+(test *)
+(run *)	(round 4 to the nearest 10 into 0)
 
-(test #sort-4-2)
-	(sort 4 2 into 2 4)
+#round-5-10
+(test *)
+(run *)	(round 5 to the nearest 10 into 10)
 
-(test #sort-2-4)
-	(sort 2 4 into 2 4)
+#round-14-10
+(test *)
+(run *)	(round 14 to the nearest 10 into 10)
 
-(test #sort-0-0)
-	(sort 0 0 into 0 0)
+#round-15-20
+(test *)
+(run *)	(round 15 to the nearest 10 into 20)
 
-(test #sort-1-2-3)
-	(sort 1 2 3 into 1 2 3)
+#delta-4-2
+(test *)
+(run *)	(4 delta 2 into 2)
 
-(test #sort-1-3-2)
-	(sort 1 3 2 into 1 2 3)
+#delta-2-4
+(test *)
+(run *)p	(2 delta 4 into 2)
 
-(test #sort-2-3-1)
-	(sort 2 3 1 into 1 2 3)
+#delta-2-2
+(test *)
+(run *)	(2 delta 2 into 0)
 
-(test #sort-2-1-3)
-	(sort 2 1 3 into 1 2 3)
+#delta-0-0
+(test *)
+(run *)	(0 delta 0 into 0)
 
-(test #sort-3-2-1)
-	(sort 3 2 1 into 1 2 3)
+#range-5-3
+(test *)
+(run *)	(5 is within 2 of 3)
 
-(test #sort-3-1-2)
-	(sort 3 1 2 into 1 2 3)
+#range-3-5
+(test *)
+(run *)	(3 is within 2 of 5)
 
-(test #10-plus-20)
-	(add 10 to 20 into 30)
+#range-3-3
+(test *)
+(run *)	(3 is within 0 of 3)
 
-(test #10-plus-20-max-25)
-    (add 10 to 20 into 25 max 25)
+#range-0-3
+(test *)
+(run *)	(0 is within 3 of 3)
 
-(test #8192-plus-8191-max-16380)
-    (add 8192 to 8191 into 16380 max 16380)
+#range-0-0
+(test *)
+(run *)	(0 is within 0 of 0)
 
-(test #8192-plus-8192-max-16380)
-    (add 8192 to 8192 into 16380 max 16380)
+#3-div-3-rounding-up
+(test *)
+(run *)	(3 divided by 3 into 1 rounding up)
 
-(test #16380-plus-3)
-	(add 3 to 16380 into 16383)
+#4-div-3-rounding-up
+(test *)
+(run *)	(4 divided by 3 into 2 rounding up)
 
-(test #16380-plus-4)
-	(add 4 to 16380 into 16383)
+#5-div-3-rounding-up
+(test *)
+(run *)	(5 divided by 3 into 2 rounding up)
 
-(test #30-minus-20)
-    (subtract 20 from 30 into 10)
+#6-div-3-rounding-up
+(test *)
+(run *)	(6 divided by 3 into 2 rounding up)
 
-(test #30-minus-40)
-    (subtract 40 from 30 into 0)
+#intentionally-fail-this-test
+(test *)
+(run *)	(fail)
 
-(test #split-number)
-	(split 1789 into 1 7 8 9)
+#sort-4-2
+(test *)
+(run *)	(sort 4 2 into 2 4)
 
-(test #split-smaller)
-	(split 789 into 0 7 8 9)
+#sort-2-4
+(test *)
+(run *)	(sort 2 4 into 2 4)
 
-(test #split-smallest)
-	(split 1 into 0 0 0 1)
+#sort-0-0
+(test *)
+(run *)	(sort 0 0 into 0 0)
 
-(test #take-last-n)
-	(take last 3 from [1 2 3 4 5 6] into [4 5 6])
+#sort-1-2-3
+(test *)
+(run *)	(sort 1 2 3 into 1 2 3)
 
-(test #take-last-zero)
-	(take last 0 from [1 2 3 4 5 6] into [])
+#sort-1-3-2
+(test *)
+(run *)	(sort 1 3 2 into 1 2 3)
 
-(test #take-last-more-than-len)
-	~(take last 7 from [1 2 3 5 6 7] into $)
+#sort-2-3-1
+(test *)
+(run *)	(sort 2 3 1 into 1 2 3)
 
-(test #replace-element)
-	(replace element 3 in [1 2 3 4 5] with 6 into [1 2 6 4 5])
+#sort-2-1-3
+(test *)
+(run *)	(sort 2 1 3 into 1 2 3)
 
-(test #replace-element-zero)
-	~(replace element 0 in [1 2 3 4 5] with 6 into $)
+#sort-3-2-1
+(test *)
+(run *)	(sort 3 2 1 into 1 2 3)
 
-(test #replace-element-beyond-end)
-	~(replace element 6 in [1 2 3 4 5] with 6 into $)
+#sort-3-1-2
+(test *)
+(run *)	(sort 3 1 2 into 1 2 3)
 
-(test #replace-element-with-max)
-	(replace element 3 in [1 2 3 4 5] with 6 into [1 2 6 4 5] with max 7)
+#10-plus-20
+(test *)
+(run *)	(add 10 to 20 into 30)
 
-(test #replace-element-beyond-max)
-	(replace element 3 in [1 2 3 4 5] with 8 into [1 2 7 4 5] with max 7)
+#10-plus-20-max-25
+(test *)
+(run *)    (add 10 to 20 into 25 max 25)
 
-(test #increase-element)
-	(increase element 3 in [1 2 3 4 5] by 3 into [1 2 6 4 5])
+#8192-plus-8191-max-16380
+(test *)
+(run *)    (add 8192 to 8191 into 16380 max 16380)
 
-(test #increase-element-zero)
-	~(increase element 0 in [1 2 3 4 5] by 3 into $)
+#8192-plus-8192-max-16380
+(test *)
+(run *)    (add 8192 to 8192 into 16380 max 16380)
 
-(test #increase-element-beyond-end)
-	~(increase element 6 in [1 2 3 4 5] by 3 into $)
+#16380-plus-3
+(test *)
+(run *)	(add 3 to 16380 into 16383)
 
-(test #increase-element-with-max)
-	(increase element 3 in [1 2 3 4 5] by 3 into [1 2 6 4 5] with max 7)
+#16380-plus-4
+(test *)
+(run *)	(add 4 to 16380 into 16383)
 
-(test #increase-element-beyond-max)
+#30-minus-20
+(test *)
+(run *)    (subtract 20 from 30 into 10)
+
+#30-minus-40
+(test *)
+(run *)    (subtract 40 from 30 into 0)
+
+#split-number
+(test *)
+(run *)	(split 1789 into 1 7 8 9)
+
+#split-smaller
+(test *)
+(run *)	(split 789 into 0 7 8 9)
+
+#split-smallest
+(test *)
+(run *)	(split 1 into 0 0 0 1)
+
+#take-last-n
+(test *)
+(run *)	(take last 3 from [1 2 3 4 5 6] into [4 5 6])
+
+#take-last-zero
+(test *)
+(run *)	(take last 0 from [1 2 3 4 5 6] into [])
+
+#take-last-more-than-len
+(test *)
+(run *)	~(take last 7 from [1 2 3 5 6 7] into $)
+
+#replace-element
+(test *)
+(run *)	(replace element 3 in [1 2 3 4 5] with 6 into [1 2 6 4 5])
+
+#replace-element-zero
+(test *)
+(run *)	~(replace element 0 in [1 2 3 4 5] with 6 into $)
+
+#replace-element-beyond-end
+(test *)
+(run *)	~(replace element 6 in [1 2 3 4 5] with 6 into $)
+
+#replace-element-with-max
+(test *)
+(run *)
+	 (replace element 3 in [1 2 3 4 5] with 6 into [1 2 6 4 5] with max 7)
+
+#replace-element-beyond-max
+(test *)
+(run *)
+	 (replace element 3 in [1 2 3 4 5] with 8 into [1 2 7 4 5] with max 7)
+
+#increase-element
+(test *)
+(run *)
+	 (increase element 3 in [1 2 3 4 5] by 3 into [1 2 6 4 5])
+
+#increase-element-zero
+(test *)
+(run *)
+	 ~(increase element 0 in [1 2 3 4 5] by 3 into $)
+
+#increase-element-beyond-end
+(test *)
+(run *)
+	 ~(increase element 6 in [1 2 3 4 5] by 3 into $)
+
+#increase-element-with-max
+(test *)
+(run *)
+	 (increase element 3 in [1 2 3 4 5] by 3 into [1 2 6 4 5] with max 7)
+
+#increase-element-beyond-max
+(test *)
+(run *)
 	(increase element 3 in [1 2 3 4 5] by 5 into [1 2 7 4 5] with max 7)
 
-(test #decrease-element)
+#decrease-element
+(test *)
+(run *)
 	(decrease element 3 in [1 2 3 4 5] by 2 into [1 2 1 4 5])
 
-(test #decrease-element-zero)
+#decrease-element-zero
+(test *)
+(run *)
 	~(decrease element 0 in [1 2 3 4 5] by 2 into $)
 
-(test #decrease-element-beyond-end)
+#decrease-element-beyond-end
+(test *)
+(run *)
 	~(decrease element 6 in [1 2 3 4 5] by 2 into $)
 
-(test #decrease-element-below-zero)
+#decrease-element-below-zero
+(test *)
+(run *)
 	~(decrease element 3 in [1 2 3 4 5] by 4 into $)
 
-(test #match-one-of-the-key)
+#match-one-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 1 is 1 into [[1 2 3 4 5]])
 
-(test #match-three-of-the-key)
+#match-three-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 3 is 4 into [
 	    [2 2 4 5 6]
 	    [3 2 4 5 6]
 	    [3 2 4 6 7]])
 
-(test #match-zero-of-the-key)
+#match-zero-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 5 is 8 into [])
 
-(test #match-not-one-of-the-key)
+#match-not-one-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 1 is not 1 into [
 		[2 2 4 5 6]
@@ -318,106 +346,164 @@
 		[3 2 4 6 7]
 		[4 1 7 8 9]])
 
-(test #match-not-three-of-the-key)
+#match-not-three-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 3 is not 4 into [
 	    [1 2 3 4 5]
 	    [4 1 7 8 9]])
 
-(test #match-not-zero-of-the-key)
+#match-not-zero-of-the-key
+(test *)
+(run *)
 	(list of lists $List)
 	(take from $List where element 5 is not 8 into $List)
 
-(test #dont-match-element-0)
+#dont-match-element-0
+(test *)
+(run *)
 	(list of lists $List)
 	~(take from $List where element 0 is 8 into $)
 
-(test #dont-match-element-beyond-end)
+#dont-match-element-beyond-end
+(test *)
+(run *)
 	(list of lists $List)
 	~(take from $List where element 6 is 8 into $)
 
-(test #12345-begins-with-12)
+#12345-begins-with-12
+(test *)
+(run *)
 	([1 2 3 4 5] begins with sublist [1 2])
 
-(test #12345-begins-with-12345)
+#12345-begins-with-12345
+(test *)
+(run *)
 	([1 2 3 4 5] begins with sublist [1 2 3 4 5])
 
-(test #12345-doesnt-begin-with-22)
+#intentionally-fail-this-one-also
+(test *)
+(run *)	(fail)
+
+#12345-doesnt-begin-with-22
+(test *)
+(run *)
 	~([1 2 3 4 5] begins with sublist [2 2])
 
-(test #12345-doesnt-begin-with-123456)
+#12345-doesnt-begin-with-123456
+(test *)
+(run *)
 	~([1 2 3 4 5] begins with sublist [1 2 3 4 5 6])
 
-(test #12345-doesnt-begin-with-scalar)
+#12345-doesnt-begin-with-scalar
+(test *)
+(run *)
 	~([1 2 3 4 5] begins with sublist 1)
 
-(test #12345-doesnt-begin-with-nested)
+#12345-doesnt-begin-with-nested
+(test *)
+(run *)
 	~([1 2 3 4 5] begins with sublist [[1] [2]])
 
-(test #find-12)
+#find-12
+(test *)
+(run *)
     (list of lists $List)
 	(find in $List beginning with sublist [1 2] into [1 2 3 4 5])
 
-(test #find-22)
+#find-22
+(test *)
+(run *)
     (list of lists $List)
 	(find in $List beginning with sublist [2 2] into [2 2 4 5 6])
 
-(test #dont-find-99)
+#dont-find-99
+(test *)
+(run *)
     (list of lists $List)
 	~(find in $List beginning with sublist [9 9] into $)
 
-(test #dont-find-123456)
+#dont-find-123456
+(test *)
+(run *)
     (list of lists $List)
 	~(find in $List beginning with sublist [1 2 3 4 5 6] into $)
 
-(test #dont-find-scalar)
+#dont-find-scalar
+(test *)
+(run *)
     (list of lists $List)
 	~(find in $List beginning with sublist 1 into $)
 
-(test #dont-find-in-empty-list)
+#dont-find-in-empty-list
+(test *)
+(run *)
 	~(find in [] beginning with sublist [1 2] into $)
 
-(test #set-1-in-1-to-2)
+#set-1-in-1-to-2
+(test *)
+(run *)
     (set element 1 in [1] in [[1]] to 2 into [[2]])
 
-(test #set-1-in-2-to-2)
+#set-1-in-2-to-2
+(test *)
+(run *)
     (set element 1 in [2] in [[1]] to 2 into [[1]])
 
-(test #set-2-in-22-to-3)
+#set-2-in-22-to-3
+(test *)
+(run *)
     (set element 2 in [2] in [[1 2] [2 2]] to 3 into [[1 2] [2 3]])
 
-(test #set-2-in-22-to-4)
+#set-2-in-22-to-4
+(test *)
+(run *)
     (set element 2 in [2] in [[1 2] [2 2] [3 2]] to 4 into [[1 2] [2 4] [3 2]])
 
-(test #set-4-in-12345-to-6)
+#set-4-in-12345-to-6
+(test *)
+(run *)
 	(list of lists $List)
 	(set element 4 in [1 2] in $List to 6 into $NewList)
 	(length of $NewList into 5)
 	(find in $NewList beginning with sublist [1 2] into [1 2 3 6 5])
 
-(test #set-4-in-32456-to-7)
+#set-4-in-32456-to-7
+(test *)
+(run *)
 	(list of lists $List)
 	(set element 4 in [3 2] in $List to 7 into $NewList)
 	(length of $NewList into 5)
 	(find in $NewList beginning with sublist [3 2] into [3 2 4 7 6])
 
-(test #dont-set-6-in-12345)
+#dont-set-6-in-12345
+(test *)
+(run *)
 	(list of lists $List)
 	~(set element 6 in [1 2] in $List to 6 into $)
 
-(test #dont-set-0-in-12345)
+#dont-set-0-in-12345
+(test *)
+(run *)
 	(list of lists $List)
 	~(set element 0 in [1 2] in $List to 6 into $)
 
-(test #find-type-and-id)
+#find-type-and-id
+(test *)
+(run *)
 	  (list of lists $List)
 	  (find 2 2 in $List into [2 2 4 5 6])
 
-(test #dont-find-type-and-id)
+#dont-find-type-and-id
+(test *)
+(run *)
 	  (list of lists $List)
 	  ~(find 9 9 in $List into $)
 
-(test #remove-1-2)
+#remove-1-2
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 1 2 from $List into $NewList)
 	  (assert $NewList = [
@@ -426,7 +512,9 @@
 		[3 2 4 6 7]
 		[4 1 7 8 9]])
 
-(test #remove-1-2-twice)
+#remove-1-2-twice
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 1 2 from $List into $NewList)
 	  (remove 1 2 from $NewList into $NewerList)
@@ -436,7 +524,9 @@
 		[3 2 4 6 7]
 		[4 1 7 8 9]])
 
-(test #remove-2-2)
+#remove-2-2
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 2 2 from $List into $NewList)
 	  (assert $NewList = [
@@ -445,7 +535,9 @@
 		[3 2 4 6 7]
 		[4 1 7 8 9]])
 
-(test #remove-3-2)
+#remove-3-2
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 3 2 from $List into $NewList)
 	  (assert $NewList = [
@@ -454,7 +546,9 @@
 		[3 2 4 6 7]
 		[4 1 7 8 9]])
 
-(test #remove-3-2-twice)
+#remove-3-2-twice
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 3 2 from $List into $NewList)
 	  (remove 3 2 from $NewList into $NewerList)
@@ -463,7 +557,9 @@
 		[2 2 4 5 6]
 		[4 1 7 8 9]])
 
-(test #remove-4-1)
+#remove-4-1
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 4 1 from $List into $NewList)
 	  (assert $NewList = [
@@ -472,30 +568,46 @@
 		[3 2 4 5 6]
 		[3 2 4 6 7]])
 
-(test #remove-7-7)
+#remove-7-7
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove 7 7 from $List into $List)
 
-(test #remove-in-filter)
+#remove-in-filter
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove from $List found in [[1 2] [4 1]] into [
 		[2 2 4 5 6]
 		[3 2 4 5 6]
 		[3 2 4 6 7]])
 
-(test #remove-multiple-match)
+#remove-multiple-match
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove from $List found in [[3 2] [4 1]] into [
 		[1 2 3 4 5]
 		[2 2 4 5 6]])
 
-(test #remove-in-empty-filter)
+#remove-in-empty-filter
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove from $List found in [] into $List)
 
-(test #remove-empty-list-in-filter)
+#remove-empty-list-in-filter
+(test *)
+(run *)
 	  (remove from [] found in [[1 2] [4 1]] into [])
 
-(test #remove-in-disjoint-filter)
+#remove-in-disjoint-filter
+(test *)
+(run *)
 	  (list of lists $List)
 	  (remove from $List found in [[7 8] [9 9]] into $List)
+
+#intentionally-fail-yet-another
+(test *)
+(run *)	(fail)

--- a/test/unit/utils.dg
+++ b/test/unit/utils.dg
@@ -1,5 +1,5 @@
 %% utils.dg
-%% Useful utility routines for Dialog projects.
+%% Grab bag of useful utility routines for Dialog projects.
 
 (extension version)	Arithmetic and list handling v0.2 by Susan Davis (line)
 
@@ -11,6 +11,8 @@
 (interface ($<Number is odd))  %% yagni?
 
 (interface ($<Number is even)) %% yagni?
+
+(interface (round $<Num to the nearest $<Increment into $>Result))
 
 (interface (max $<X and $<Y into $>Max))
 
@@ -100,6 +102,16 @@
 	(else)
 		($Result = $Y)
 	(endif)
+
+(round $Num to the nearest $Increment into $Result)
+	($Num modulo $Increment into $Mod)
+	($Increment divided by 2 into $Div rounding up)
+	(if) ($Div > $Mod) (then)
+		($Num divided by $Increment into $Multiplier)
+	(else)
+		($Num divided by $Increment into $Multiplier rounding up)
+	(endif)
+	($Increment times $Multiplier into $Result)
 
 ($X delta $Y into $Result)
 	(if) ($X > $Y) (then)

--- a/test/unit/zero-tests.dg
+++ b/test/unit/zero-tests.dg
@@ -1,1 +1,1 @@
-(list of tests [])
+%% this file intentionally left blank

--- a/unit.dg
+++ b/unit.dg
@@ -68,7 +68,7 @@
 	(no space) . (roman) (line)
 	(stoppable) (exhaust) {
 		*(test $Test)
-		(run-test $Test)
+		(run test $Test)
 	}
 	(reset body style)
 	(list of failures $Failures)
@@ -106,7 +106,7 @@
 	(append $List [$Test] $ListPlusTest)
 	(now) (list of failures $ListPlusTest)
 
-(run-test $Test)
+(run test $Test)
 	(update body style)
 	Testing $Test :
 	(reset body style) %% display output from the test itself in default colours

--- a/unit.dg
+++ b/unit.dg
@@ -62,8 +62,7 @@
 (global variable (list of failures []))
 
 (program entry point)
-	(collect $T) *(test $T) (into $Tests)
-	(length of $Tests into $Number)
+	(accumulate 1) *(test $) (into $Number)
 	(bold) Attempting $Number test
 	(if) ~($Number = 1) (then) (no space) s (endif)
 	(no space) . (roman) (line)

--- a/unit.dg
+++ b/unit.dg
@@ -1,5 +1,5 @@
 %% unit.dg
-(extension version)	Unit test runner 2.0-dev by Susan Davis (line)
+(extension version)	Unit test runner 1.2.1 by Susan Davis (line)
 
 %% See example(s) in test/unit in Dialog source distribution.
 

--- a/unit.dg
+++ b/unit.dg
@@ -1,5 +1,5 @@
 %% unit.dg
-(extension version)	Unit test runner 1.2.0 by Susan Davis (line)
+(extension version)	Unit test runner 2.0-dev by Susan Davis (line)
 
 %% See example(s) in test/unit in Dialog source distribution.
 
@@ -8,10 +8,14 @@
 
 %%-------------------------------- INTERFACES --------------------------------
 
-%% (test #foo) expr will pass if expr is true and fail if expr is false.
+%% Give all your tests the (test *) trait.
+
+(interface (test $Testname))
+
+%% (run #foo) expr will pass if expr is true and fail if expr is false.
 %% Include #foo in the global variable (list of tests [test1 test2 ...])
 
-(interface (test $<Testname))
+(interface (run $<Testname))
 
 (interface (set up $<Testname)) %% special setup for the test
 
@@ -28,13 +32,6 @@
 (using color) %% negate to use default output instead of green and red
 
 ~(list failing tests) %% un-negate to summarize failing tests at the end
-
-%% We can't just (exhaust *(test $)), because that actually runs each test
-%% without setup, cleanup, or failure checks, so we work around that with
-%% a global variable, populated with all the tests. You can quarantine tests
-%% by commenting out their entry in the global variable declaration.
-
-(global variable (list of tests $))
 
 %%----------------------------- IMPLEMENTATION -----------------------------
 
@@ -65,13 +62,13 @@
 (global variable (list of failures []))
 
 (program entry point)
-	(list of tests $Tests)
+	(collect $T) *(test $T) (into $Tests)
 	(length of $Tests into $Number)
 	(bold) Attempting $Number test
 	(if) ~($Number = 1) (then) (no space) s (endif)
 	(no space) . (roman) (line)
 	(stoppable) (exhaust) {
-		*($Test is one of $Tests)
+		*(test $Test)
 		(run-test $Test)
 	}
 	(reset body style)
@@ -116,7 +113,7 @@
 	(reset body style) %% display output from the test itself in default colours
 	(if)
 		(stoppable) (exhaust) *(set up $Test)   %% don't fail if absent
-		(test $Test)
+		(run $Test)
 		(stoppable) (exhaust) *(clean up $Test) %% don't fail if absent
 	(then)
 		(update body style)
@@ -137,31 +134,30 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% License and copyright notice
-
 %% Copyright 2018-2026 the Dialog Project contributors
-%% 
+%%
 %% Redistribution and use in source and binary forms, with or without
 %% modification, are permitted provided that the following conditions are met:
-%% 
-%%		1. Redistributions of source code must retain the above copyright
-%%		notice, this list of conditions and the following disclaimer.
-%% 
-%%		2. Redistributions in binary form must reproduce the above copyright
-%%		notice, this list of conditions and the following disclaimer in the
-%%		documentation and/or other materials provided with the distribution.
-%% 
-%%		THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-%%		IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-%%		TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-%%		PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-%%		HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-%%		SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-%%		LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-%%		DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-%%		THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-%%		(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-%%		OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-%% 
+%%
+%%  1. Redistributions of source code must retain the above copyright
+%%      notice, this list of conditions and the following disclaimer.
+%%
+%%  2. Redistributions in binary form must reproduce the above copyright
+%%     notice, this list of conditions and the following disclaimer in the
+%%     documentation and/or other materials provided with the distribution.
+%%
+%%     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+%%     IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+%%     TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+%%     PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+%%     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+%%     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+%%     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+%%     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+%%     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+%%     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+%%     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+%%
 %% This license is intended to apply to the Dialog compiler and debugger and
 %% the source code of the standard libraries. Any time those components are
 %% distributed, this copyright notice should be attached. But it is not meant
@@ -169,12 +165,12 @@
 %% include the standard libraries. To make this explicit, the project is ALSO
 %% released under a modified two-clause BSD license, which is exactly the same
 %% as the above but adds this exception:
-%% 
-%%		As an exception, if, as a result of you compiling your source code,
-%%		portions of this software are embedded into compiler output in binary
-%%		form, you may redistribute such embedded portions without complying
-%%		with condition 2 of the license.
-%% 
+%%
+%%     As an exception, if, as a result of you compiling your source code,
+%%     portions of this software are embedded into compiler output in binary
+%%     form, you may redistribute such embedded portions without complying
+%%     with condition 2 of the license.
+%%
 %% In other words, you can distribute the Z-machine and Å-machine bytecode that
 %% the compiler produces in any way you like, without needing to include this
 %% license file or comply with the attribution requirements (for the library


### PR DESCRIPTION
`unit.dg` now expects each test to be flagged with trait `(test $)` and have a predicate `(run $)` that executes the test and succeeds or fails. The `(list of tests $)` global variable is gone.