### PR TITLE
make license text fit in 80 columns

### DIFF
--- a/stddebug.dg
+++ b/stddebug.dg
@@ -70,31 +70,30 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% License and copyright notice
-
-%% Copyright 2018-2026 Linus Åkesson and the Dialog Project contributors
-%% 
+%% Copyright 2018-2026 the Dialog Project contributors
+%%
 %% Redistribution and use in source and binary forms, with or without
 %% modification, are permitted provided that the following conditions are met:
-%% 
-%%		1. Redistributions of source code must retain the above copyright
-%%		notice, this list of conditions and the following disclaimer.
-%% 
-%%		2. Redistributions in binary form must reproduce the above copyright
-%%		notice, this list of conditions and the following disclaimer in the
-%%		documentation and/or other materials provided with the distribution.
-%% 
-%%		THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-%%		IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-%%		TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-%%		PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-%%		HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-%%		SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-%%		LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-%%		DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-%%		THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-%%		(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-%%		OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-%% 
+%%
+%%  1. Redistributions of source code must retain the above copyright
+%%      notice, this list of conditions and the following disclaimer.
+%%
+%%  2. Redistributions in binary form must reproduce the above copyright
+%%     notice, this list of conditions and the following disclaimer in the
+%%     documentation and/or other materials provided with the distribution.
+%%
+%%     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+%%     IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+%%     TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+%%     PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+%%     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+%%     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+%%     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+%%     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+%%     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+%%     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+%%     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+%%
 %% This license is intended to apply to the Dialog compiler and debugger and
 %% the source code of the standard libraries. Any time those components are
 %% distributed, this copyright notice should be attached. But it is not meant
@@ -102,12 +101,12 @@
 %% include the standard libraries. To make this explicit, the project is ALSO
 %% released under a modified two-clause BSD license, which is exactly the same
 %% as the above but adds this exception:
-%% 
-%%		As an exception, if, as a result of you compiling your source code,
-%%		portions of this software are embedded into compiler output in binary
-%%		form, you may redistribute such embedded portions without complying
-%%		with condition 2 of the license.
-%% 
+%%
+%%     As an exception, if, as a result of you compiling your source code,
+%%     portions of this software are embedded into compiler output in binary
+%%     form, you may redistribute such embedded portions without complying
+%%     with condition 2 of the license.
+%%
 %% In other words, you can distribute the Z-machine and Å-machine bytecode that
 %% the compiler produces in any way you like, without needing to include this
 %% license file or comply with the attribution requirements (for the library

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -3995,7 +3995,7 @@
 	(endif)
 
 (narrate $Obj leaving $ $Dir to $NewRoom)
-	(The $Obj) disappear(s $Obj) (name $Dir) 
+	(The $Obj) disappear(s $Obj) (name $Dir)
 	(if) ($NewRoom is visited) (then) to (the $NewRoom) (endif).
 
 (narrate $Obj entering $NewRoom from $OldRoom)
@@ -4524,7 +4524,7 @@
 (notice $Obj)
 	(if) (object $Obj) (then)
 		(reveal $Obj)
-		
+
 		%% Should we set plural pronouns?
 		(if)
 			(ambiguously plural $Obj) (or)
@@ -4534,7 +4534,7 @@
 		(then)
 			(now) (them refers to [$Obj])
 		(endif)
-		
+
 		%% Should we set singular pronouns?
 		(if)
 			(ambiguously plural $Obj) (or)
@@ -4556,7 +4556,7 @@
 				(endif)
 			(endif)
 		(endif)
-		
+
 	(elseif) (list $Obj) (then)
 		(if) ($Obj = [$Single]) (then)
 			(notice $Single)
@@ -4567,7 +4567,7 @@
 
 (notice player's $Obj)
 	(if) ~(current player $Obj) (then)
-		
+
 		(if) (list $Obj) (then)
 			(if) ($Obj = [$Single]) (then)
 				(notice player's $Single)
@@ -4575,7 +4575,7 @@
 				(now) (them refers to $Obj)
 			(endif)
 		(else)
-			
+
 			%% Should we set plural pronouns?
 			(if)
 				(ambiguously plural $Obj) (or)
@@ -4585,7 +4585,7 @@
 			(then)
 				(now) (them refers to [$Obj])
 			(endif)
-			
+
 			%% Should we set singular pronouns?
 			(if)
 				(ambiguously plural $Obj) (or)
@@ -4606,7 +4606,7 @@
 					(endif)
 				(endif)
 			(endif)
-		
+
 		(endif)
 	(endif)
 
@@ -4946,7 +4946,7 @@
 				(now) ~(moving long distances)
 				(now) ~(last step of movement)
 			(endif)
-			
+
 			(if)
 				(scoring enabled)
 				(score notifications are on)
@@ -6683,31 +6683,30 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% License and copyright notice
-
-%% Copyright 2018-2026 Linus Åkesson and the Dialog Project contributors
-%% 
+%% Copyright 2018-2026 the Dialog Project contributors
+%%
 %% Redistribution and use in source and binary forms, with or without
 %% modification, are permitted provided that the following conditions are met:
-%% 
-%%		1. Redistributions of source code must retain the above copyright
-%%		notice, this list of conditions and the following disclaimer.
-%% 
-%%		2. Redistributions in binary form must reproduce the above copyright
-%%		notice, this list of conditions and the following disclaimer in the
-%%		documentation and/or other materials provided with the distribution.
-%% 
-%%		THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-%%		IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-%%		TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-%%		PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-%%		HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-%%		SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-%%		LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-%%		DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-%%		THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-%%		(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-%%		OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-%% 
+%%
+%%  1. Redistributions of source code must retain the above copyright
+%%      notice, this list of conditions and the following disclaimer.
+%%
+%%  2. Redistributions in binary form must reproduce the above copyright
+%%     notice, this list of conditions and the following disclaimer in the
+%%     documentation and/or other materials provided with the distribution.
+%%
+%%     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+%%     IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+%%     TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+%%     PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+%%     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+%%     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+%%     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+%%     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+%%     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+%%     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+%%     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+%%
 %% This license is intended to apply to the Dialog compiler and debugger and
 %% the source code of the standard libraries. Any time those components are
 %% distributed, this copyright notice should be attached. But it is not meant
@@ -6715,12 +6714,12 @@
 %% include the standard libraries. To make this explicit, the project is ALSO
 %% released under a modified two-clause BSD license, which is exactly the same
 %% as the above but adds this exception:
-%% 
-%%		As an exception, if, as a result of you compiling your source code,
-%%		portions of this software are embedded into compiler output in binary
-%%		form, you may redistribute such embedded portions without complying
-%%		with condition 2 of the license.
-%% 
+%%
+%%     As an exception, if, as a result of you compiling your source code,
+%%     portions of this software are embedded into compiler output in binary
+%%     form, you may redistribute such embedded portions without complying
+%%     with condition 2 of the license.
+%%
 %% In other words, you can distribute the Z-machine and Å-machine bytecode that
 %% the compiler produces in any way you like, without needing to include this
 %% license file or comply with the attribution requirements (for the library


### PR DESCRIPTION
Convert tabs to spaces to get the license text at the bottom of the libraries (`stdlib.dg`, `stddebug.dg`, and `unit.dg`) to fit in 80 columns and not look like ass.