### PR TITLE
Make Z-machine backend align with Å-machine on inline status bars

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,11 @@ Release notes:
 
 	1b/02:
 
+		Backend: (inline status bar $) will now produce a line break on
+		Z-machine. It's unclear whether this was Linus's intent, but it
+		matches both the Node and 6502 Å-machine interpreters, so the
+		Z-machine has been updated for consistency.
+		
 		Unit test runner: unit.dg has been redesigned. Unit tests written
 		against the version from 1b/01 will need to be rewritten along
 		the lines of time-tests.dg and utils-tests.dg in the test/unit

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -3633,6 +3633,8 @@ struct rtroutine rtroutines[] = {
 
 			{OP_LABEL(1)},
 			{Z_JNZ, {VALUE(REG_NSPAN)}, 0, 2},
+			
+			{Z_CALL1N, {ROUTINE(R_LINE)}}, // Break lines around inline status bars. It's unclear if this is intended behavior, but both the 6502 and Node Å-machine terps do it, so it seems best to make the Z-machine align with that.
 
 			{Z_STORE, {SMALL(REG_STATUSBAR), SMALL(2)}},
 			{Z_RFALSE},

--- a/test/simple/language/new_body_not_status.gold
+++ b/test/simple/language/new_body_not_status.gold
@@ -1,7 +1,6 @@
 [A]
 [DA] Outside line 1.
 [Z] This is a top status bar.
-[DA] Outside line 2.
+Outside line 2.
 [D] This is an inline status bar.
-[DA] Outside line 3. Outside line 4.
-[Z] Outside line 2.Outside line 3. Outside line 4.
+Outside line 3. Outside line 4.


### PR DESCRIPTION
Fixes #251 

As discussed in the readme and runtime_z.c, it's unclear whether this would match Linus's intent. But it matches the reference interpreters for the Å-machine, and consistency seems like the best policy here. We can easily change it back in the future if need be.