### PR TITLE
Use aamrun binary if available

### DIFF
--- a/bin/aamrun.py
+++ b/bin/aamrun.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 from sys import argv, exit, stderr
 import subprocess as sp
+import shutil
 
 USAGE = f'''Usage: {argv[0]} [file.aastory]
 Attempts to play an .aastory file in the Node interpreter (with consistent random seed for testing), despite varying install locations.'''
@@ -12,6 +13,12 @@ Attempts to play an .aastory file in the Node interpreter (with consistent rando
 if len(argv) != 2 or argv[1] in {'--help', '-h'}:
 	print(USAGE, file=stderr)
 	exit(1)
+
+# The aamachine distribution now includes an aamrun binary
+# If that exists on the $PATH, then we can sidestep this whole mess
+if shutil.which('aamrun') is not None:
+	sp.run(['aamrun', '-s', '1234', argv[1]])
+	exit(0)
 
 BASE = Path(__file__).resolve().parent.parent # Root of the repository
 TOSEARCH = [

--- a/bin/abbrevmaker.py
+++ b/bin/abbrevmaker.py
@@ -12,7 +12,7 @@ MAX_ABBREVS = 96
 
 PATTERN = r'Abbreviate "([^"]+)";\s+\!.*'
 
-REPLACEMENTS = { '~':'\\"', '^':'\\n' } # Undo Inform string escaping (or rather replace it with C string escaping
+REPLACEMENTS = { '~':'\\"', '^':'\\n' } # Undo Inform string escaping (or rather replace it with C string escaping)
 
 abbrevs = []
 
@@ -29,7 +29,7 @@ num_found = len(abbrevs)
 print(f'Total: {num_found}/{MAX_ABBREVS}')
 
 # Step 2: build the index
-index = defaultdict(list) # first char : [longest ... shortest]
+index = defaultdict(list) # first char : [longest, ..., shortest]
 for abr in abbrevs:
 	c = abr[0]
 	index[c].append(abr)

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# This script will ump the version in all the "authoritative" places.
-# You may also need to regenerate test output that embeds the version.
+# This script will bump the version in all the "authoritative" places.
+# Test output should no longer care about this, but run `make test` afterward to make sure
+# Usage: ./bump-version.sh 1a/01-dev 1.1.0
 
 set -euo pipefail
 cd "$(dirname "$0")/.."

--- a/bin/echoing.py
+++ b/bin/echoing.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# This script is an awful hack around a limitation of dumbfrotz
+# Unlike dgdebug, it doesn't echo each line of input to stdout when reading from a file
+# So we need to manually insert those lines back in for the automated tests to work
+# This has horribly glaring race conditions which occasionally cause the tests to fail
+# So hopefully dumbfrotz can get fixed at some point so we no longer need this
+
 from sys import argv, stdin
 import subprocess as sp
 from time import sleep
@@ -11,6 +17,7 @@ if len(argv) == 1 or argv[1] in {'--help', '-h'}:
 proc = sp.Popen(argv[1:], stdin=sp.PIPE, text=True, bufsize=1)
 for line in stdin:
 	sleep(0.01) # Tiny delay to sync, assuming the game won't take longer than this to run each turn on modern hardware
+	# Ideally we could detect when dumbfrotz wants input instead - possibly with the line tagging option? TODO
 	print(line, end='', flush=True)
 	proc.stdin.write(line)
 	proc.stdin.flush()

--- a/bin/test.py
+++ b/bin/test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python3
+
+# This script attempts to extract all Dialog snippets from the manual and run them
+# They must not crash (unless tagged as such), and if there's following output in the manual page, that must match too
+
 import os
 import argparse
 import re
@@ -9,7 +13,7 @@ from pathlib import Path
 from typing import List, Set, Optional
 
 
-DEFAULT_DGDEBUG = ['src/dgdebug', '--quit', '--width=1000']
+DEFAULT_DGDEBUG = ['src/dgdebug', '--quit', '--width=-1']
 LANG_DOCS = Path('manual/modules/lang')
 LIB_DOCS = Path('manual/modules/lib')
 


### PR DESCRIPTION
Fixes #174 , assuming Homebrew puts aamrun on the $PATH.

Which I'm not sure it does. I'd appreciate if either @susan-davis or @hlship can test this with a proper Homebrew installation on Mac and make sure the Python script is locating it correctly. Currently it runs `which aamrun`, and if that succeeds, it assumes it can use `aamrun -s 1234 file.aastory` instead of `node path/to/nodefrontend.js -s 1234 file.aastory`.