### PR TITLE
fix wrong syntax for example

### DIFF
--- a/manual/modules/lib/pages/testing.adoc
+++ b/manual/modules/lib/pages/testing.adoc
@@ -120,8 +120,9 @@ simply test like this:
 
 [source]
 ----
-(test #max-first-is-bigger)
-    (max 3 2 3)
+#max-first-is-bigger
+(test *)
+(run *)    (max 3 2 3)
 ----
 
 This works because unification lets you plug in a constant value into


### PR DESCRIPTION
Missed one example when changing to the new `unit.dg` syntax.