### PR TITLE
Release 1b/02 and 1.2.1

### DIFF
--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -13,7 +13,7 @@ LIBRARY_VERSION="$2"
 
 sed -Ei "s|DIALOG_VERSION=.+|DIALOG_VERSION=$COMPILER_VERSION|" src/Makefile
 sed -Ei "s|\(library version\) Library version .+|(library version) Library version $LIBRARY_VERSION.|" stdlib.dg
-sed -Ei "s|\(extension version\) Unit test runner .+|(extension version) Unit test runner $LIBRARY_VERSION by Susan Davis (line)|" stdlib.dg
+sed -Ei "s|\(extension version\) Unit test runner .+|(extension version) Unit test runner $LIBRARY_VERSION by Susan Davis|" stdlib.dg
 
 sed -Ei "s|    lang-ver: .+|    lang-ver: $LANGUAGE_VERSION|" manual/antora.yml
 sed -Ei "s|    lib-ver: .+|    lib-ver: $LIBRARY_VERSION|" manual/antora.yml

--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -1,6 +1,6 @@
 name: dialog
 title: Dialog
-version: 1b02-dev
+version: 1b02
 nav:
   - modules/ROOT/nav.adoc
   - modules/lang/nav.adoc
@@ -8,7 +8,7 @@ nav:
 asciidoc:
   attributes:
     lang-ver: 1b
-    lib-ver: 1.2.0
+    lib-ver: 1.2.1
     old-home-page: https://linusakesson.net/dialog/
     home-page: https://github.com/Dialog-IF/dialog/
     aa-old-home-page: https://linusakesson.net/dialog/aamachine/

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ Project website:
 
 Release notes:
 
-	1b/02, Lib 1.2.0:
+	1b/02, Lib 1.2.1:
 
 		Compiler: previously, constant lists in rule heads were compiled
 		in a way that was very fast at runtime, but could crash if the
@@ -65,7 +65,8 @@ Release notes:
 		Unit test runner: unit.dg has been redesigned. Unit tests
 		written against the version from 1b/01 will need to be
 		rewritten along the lines of time-tests.dg in the test/unit
-		directory.
+		directory. (It was just released, so we don't expect many --
+		or any -- tests to have been written against the old version.)
 
 	1b/01, Lib 1.2.0:
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-DIALOG_VERSION=1b/02-dev
+DIALOG_VERSION=1b/02
 
 CC		= gcc
 CFLAGS		+= -O3 -Wall -Wno-unused-result -Wno-format-truncation -DVERSION=\"${DIALOG_VERSION}\"

--- a/stddebug.dg
+++ b/stddebug.dg
@@ -1,6 +1,5 @@
 
-(extension version)
-	Debugging extension 1.1.
+(extension version) Debugging extension 1.2.1.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Informative actions

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -1,5 +1,5 @@
 
-(library version) Library version 1.2.0.
+(library version) Library version 1.2.1.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Global variables

--- a/unit.dg
+++ b/unit.dg
@@ -1,7 +1,8 @@
 %% unit.dg
-(extension version)	Unit test runner 1.2.1 by Susan Davis (line)
+(extension version)	Unit test runner 1.2.1 by Susan Davis.
 
-%% See example(s) in test/unit in Dialog source distribution.
+%% See example(s) in test/unit in Dialog source distribution, and chapter 12 of
+%% the library manual.
 
 %% Copyright © 2021-2026, Susan Davis. All rights reserved. Licensed under the
 %% same license as the rest of Dialog; see license.txt or LICENSE for details.


### PR DESCRIPTION
`bin/bump-version.sh` gags on something on my Mac, and I didn't want to break it elsewhere, so I just bumped everything manually. Is the language version in `manual/antora.yml` supposed to be `1b`, or `1b02`?