### PR TITLE
report fatal error on exit

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,9 @@ Release notes:
 		Compiler: objects produced by (generate $ $) no longer have
 		author-accessible names, which could confuse the compiler.
 
+		Unit test runner: unit.dg now tells the author what the
+		fatal error was when it exits on a fatal error.
+
 	1c/01, Lib 1.2.2:
 
 		Library: fixed a bug where ASK FOR SOMETHING queried a random

--- a/unit.dg
+++ b/unit.dg
@@ -129,7 +129,8 @@
 	(if) (using color) (then)
 		 (body style @red-bar)
     (endif)
-	(bold) FAILED TEST -- FATAL ERROR $Code. (roman) (par)
+	(bold) FAILED TEST -- FATAL ERROR $Code: (roman)
+	(report fatal error $Code) (par)
 	(quit 2)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/unit.dg
+++ b/unit.dg
@@ -125,6 +125,15 @@
 		(if) ~(keep running on failure) (then) (stop) (endif)
 	(endif)
 
+(report fatal error 1)	Heap space exhausted.
+(report fatal error 2)	Auxiliary heap space exhausted.
+(report fatal error 3)	Type error: Expected object.
+(report fatal error 4)	Type error: Expected bound value.
+(report fatal error 5)	Invalid dynamic operation.
+(report fatal error 6)	Long-term heap space exhausted.
+(report fatal error 7)	Invalid output state.
+(report fatal error $)	Invalid error code!
+
 (error $Code entry point)
 	(if) (using color) (then)
 		 (body style @red-bar)


### PR DESCRIPTION
`unit.dg` doesn't currently tell the user what the error is when it exits with a fatal error. Use `(report fatal error $)` to fix this.