### PR TITLE
Add command-line option to disable extended ZSCII

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -48,8 +48,12 @@ Release notes:
 		Compiler: objects produced by (generate $ $) no longer have
 		author-accessible names, which could confuse the compiler.
 		
+		Backend: --basic-zscii option disables extended ZSCII. This
+		leads to larger files and worse parsing, but may be needed for
+		older interpreters that don't support Unicode.
+		
 		Debugger: fixed spurious spaces after input with --tag-lines.
-
+		
 		Unit test runner: unit.dg now tells the author what the
 		fatal error was when it exits on a fatal error.
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -88,6 +88,7 @@ void usage(char *prgname) {
 	fprintf(stderr, "Only for z5, z8, or zblorb format:\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "--no-default-unicode    Don't preserve the default Unicode translation table.\n");
+	fprintf(stderr, "--basic-zscii           Restrict the parser to default ZSCII for compatibility.\n");
 	fprintf(stderr, "--optimize-alphabet     Increase dictionary resolution for non-English letters.\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Only for zblorb format:\n");
@@ -121,8 +122,9 @@ int main(int argc, char **argv) {
 		{"long-term", 1, 0, 'L'},
 		{"word-seps", 1, 0, 'W'},
 		{"strip", 0, 0, 's'},
-		{"no-default-uni", 0, &zmachine_preserve_zscii, 0},
-		{"no-default-unicode", 0, &zmachine_preserve_zscii, 0},
+		{"no-default-uni", 0, &zmachine_preserve_zscii, ZSCII_REPLACE},
+		{"no-default-unicode", 0, &zmachine_preserve_zscii, ZSCII_REPLACE},
+		{"basic-zscii", 0, &zmachine_preserve_zscii, ZSCII_DONT_EXTEND},
 		{"warn-not-topic", 0, &topic_warning_level, WARN_ALWAYS},
 		{"no-warn-not-topic", 0, &topic_warning_level, WARN_NEVER},
 		{"optimize-alphabet", 0, &zmachine_optimize_alphabet, 1},
@@ -233,8 +235,8 @@ int main(int argc, char **argv) {
 		aamachine = 1;
 	}
 	
-	if(aamachine && !zmachine_preserve_zscii) {
-		report(LVL_WARN, 0, "The --no-default-unicode option has no effect on the aa output format");
+	if(aamachine && zmachine_preserve_zscii != ZSCII_EXTEND) {
+		report(LVL_WARN, 0, "The --no-default-unicode and --basic-zscii options have no effect on the aa output format");
 	}
 	if(aamachine && zmachine_optimize_alphabet) {
 		report(LVL_WARN, 0, "The --optimize-alphabet option has no effect on the aa output format");

--- a/src/backend.c
+++ b/src/backend.c
@@ -98,15 +98,14 @@ void usage(char *prgname) {
 	exit(1);
 }
 
-extern int zmachine_optimize_alphabet; // Defined in backend_z.c
-extern int zmachine_preserve_zscii; // Defined in backend_z.c
-
 struct output_config output_config; // Never changed from default
 
 int main(int argc, char **argv) {
 	
 	int topic_warning_level = WARN_DEFAULT;
 	int serial_overridden = 0;
+	int zmachine_optimize_alphabet = 0;
+	int zmachine_preserve_zscii = ZSCII_EXTEND;
 	
 	struct option longopts[] = {
 		{"help", 0, 0, 'h'},
@@ -277,14 +276,15 @@ int main(int argc, char **argv) {
 		prg->max_temp = aa_get_max_temp();
 	}
 	
-	if(wordseps) {
-		if(aamachine) {
-			prepare_wordseps_aa(wordseps);
-		} else {
-			prepare_wordseps_z(wordseps);
-		}
-		free(wordseps);
+	if(aamachine) {
+		configure_aa(wordseps);
 	} else {
+		configure_z(wordseps, zmachine_optimize_alphabet, zmachine_preserve_zscii);
+	}
+	
+	if(wordseps) { // If we allocated space for this, free it
+		free(wordseps);
+	} else { // Otherwise use the default (which is in static memory)
 		STOPCHARS = DEFAULT_STOPCHARS;
 	}
 

--- a/src/backend_aa.c
+++ b/src/backend_aa.c
@@ -120,7 +120,7 @@ static struct segment *segment;
 static int nsegment, nalloc_segment;
 
 static uint8_t resolve_aachar(uint32_t);
-void prepare_wordseps_aa(const uint8_t *wordseps) {
+static void prepare_wordseps(const uint8_t *wordseps) {
 	int i, len = strlen((char*)wordseps); // Overestimate
 	uint16_t unichars[len+1]; // Terminator
 	utf8_to_unicode(unichars, len+1, wordseps);
@@ -131,6 +131,10 @@ void prepare_wordseps_aa(const uint8_t *wordseps) {
 		STOPCHARS[i] = resolve_aachar(unichars[i]);
 	}
 	STOPCHARS[i] = 0;
+}
+
+void configure_aa(const uint8_t *wordseps) {
+	if(wordseps) prepare_wordseps(wordseps);
 }
 
 static int cmp_aadict(const void *a, const void *b) {

--- a/src/backend_aa.h
+++ b/src/backend_aa.h
@@ -1,6 +1,6 @@
 
 void prepare_dictionary_aa(struct program *prg);
-void prepare_wordseps_aa(const uint8_t *wordseps);
+void configure_aa(const uint8_t *wordseps);
 
 void backend_aa(
 	char *filename,

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -85,7 +85,7 @@ struct wordtable {
 
 static int warned_about_invisible_spans = 0; // To avoid a flood of warnings
 
-int zmachine_preserve_zscii = 1; // Whether to keep the default mapping (and add to the end), or empty it out (allowing more space) - this flag starts at 1 and is cleared by frontend.c if necessary
+int zmachine_preserve_zscii = ZSCII_EXTEND; // See backend_z.h for meanings; set by backend.c
 
 static uint16_t default_extended_zscii[69] = { // The default mapping, assumed by interpreters that don't support a Unicode translation table (like Ozmoo)
 	// These Unicode chars map to zscii characters 155..223 in order.
@@ -157,7 +157,7 @@ static int nwordtable;
 
 static struct backend_wobj *backendwobj;
 
-static uint8_t unicode_to_zscii(uint16_t);
+static uint8_t unicode_to_zscii(uint16_t, const char*);
 void prepare_wordseps_z(const uint8_t *wordseps) {
 	int i, len = strlen((char*)wordseps); // Overestimate
 	uint16_t unichars[len+1];
@@ -166,7 +166,7 @@ void prepare_wordseps_z(const uint8_t *wordseps) {
 	while(unichars[len]) len++; // utf8_to_unicode leaves a null terminator
 	STOPCHARS = malloc((len+1) * sizeof(uint8_t));
 	for(i = 0; i < len; i++) {
-		STOPCHARS[i] = unicode_to_zscii(unichars[i]);
+		STOPCHARS[i] = unicode_to_zscii(unichars[i], "word separators");
 	}
 	STOPCHARS[i] = 0;
 }
@@ -286,16 +286,22 @@ uint16_t resolve_rnum(uint16_t num) {
 	return r->actual_routine;
 }
 
-uint8_t add_extended_zscii(uint16_t uchar) {
+uint8_t add_extended_zscii(uint16_t uchar, const char *reason) {
 	uint8_t i = n_extended;
 	uint8_t utf8[5]; // To hold the UTF-16 character converted to UTF-8: up to four bytes plus terminator
 	// Since Z-machine only supports the BMP, really we only need *three* bytes plus terminator, but it's good to think about the future
 	
+	if(zmachine_preserve_zscii == ZSCII_DONT_EXTEND) {
+		unicode_to_utf8_n(utf8, 5, &uchar, 1); // Convert to UTF-8 sequence for error reporting
+		report(LVL_WARN, 0, "Unicode character U+%04x (%s) appeared in %s context, but could not be added due to --basic-zscii. This character will not be recognized by the parser.", uchar, utf8, reason);
+		return ' '; // Will make a word unparseable
+	}
+	
 	if(n_extended+1 >= EXTENDED_ZSCII_MAX) { // But we can't!
 		unicode_to_utf8_n(utf8, 5, &uchar, 1); // Convert to UTF-8 sequence for error reporting
-		if(zmachine_preserve_zscii) {
+		if(zmachine_preserve_zscii == ZSCII_EXTEND) {
 			report(LVL_ERR, 0, "Tried to add Unicode character U+%04x (%s) to the encoding, but all codepoints have already been allocated! Use the --no-default-unicode command line option to save space.", uchar, utf8);
-		} else {
+		} else { // ZSCII_REPLACE
 			report(LVL_ERR, 0, "Tried to add Unicode character U+%04x (%s) to the encoding, but all codepoints have already been allocated! Z-machine only supports %d non-ASCII characters in dictionary words.", uchar, utf8, EXTENDED_ZSCII_MAX);
 		}
 		exit(1);
@@ -310,7 +316,7 @@ uint8_t add_extended_zscii(uint16_t uchar) {
 	return EXTENDED_ZSCII_BASE + i;
 }
 
-static uint8_t unicode_to_zscii(uint16_t uchar) {
+static uint8_t unicode_to_zscii(uint16_t uchar, const char *reason) {
 	int i;
 
 	if(uchar < 128) {
@@ -323,7 +329,7 @@ static uint8_t unicode_to_zscii(uint16_t uchar) {
 			if(extended_zscii[i] == uchar) break;
 		}
 		if(i >= n_extended) { // Not in the encoding yet, so we add it
-			return add_extended_zscii(uchar);
+			return add_extended_zscii(uchar, reason);
 		} else {
 			return EXTENDED_ZSCII_BASE + i;
 		}
@@ -390,7 +396,7 @@ static int utf8_to_zscii(uint8_t *dest, int ndest, char *src, uint32_t *special,
 			}
 			if(i >= n_extended) { // Not found in the extended ZSCII
 				if(for_dictionary) { // Add a new character to the encoding
-					dest[outpos++] = add_extended_zscii(uchar);
+					dest[outpos++] = add_extended_zscii(uchar, "dictionary word");
 				} else { // This is in a string context instead of a dictionary context, so we don't add anything to the encoding - just return, and use @print_unicode to handle it
 					dest[outpos] = 0;
 					if(special) *special = uchar;
@@ -967,11 +973,11 @@ void prepare_dictionary_z(struct program *prg) {
 		exit(1);
 	}
 	
-	if(zmachine_preserve_zscii) { // Use the existing table as much as possible, putting our new characters at the end of it
+	if(zmachine_preserve_zscii == ZSCII_REPLACE) { // Discard the existing table, giving us the maximum space possible
+		n_extended = 0;
+	} else { // Use the existing table as much as possible, either putting our new characters at the end of it or allowing no new characters at all
 		memcpy(extended_zscii, default_extended_zscii, sizeof(default_extended_zscii));
 		n_extended = sizeof(default_extended_zscii) / sizeof(default_extended_zscii[0]);
-	} else { // Discard the existing table, giving us the maximum space possible
-		n_extended = 0;
 	}
 
 	prg->dictmap = arena_calloc(&prg->arena, prg->ndictword * sizeof(uint16_t));
@@ -4212,7 +4218,7 @@ void compile_endings_check(struct routine *r, struct endings_point *pt, int leve
 		} else {
 			ll = r->next_label++;
 		}
-		zscii = unicode_to_zscii(pt->ways[i]->letter);
+		zscii = unicode_to_zscii(pt->ways[i]->letter, "removable word endings");
 		if(verbose >= 2) {
 			for(j = 0; j < level; j++) printf("    ");
 			if(zscii >= 'a' && zscii <= 'z') {

--- a/src/backend_z.c
+++ b/src/backend_z.c
@@ -85,7 +85,7 @@ struct wordtable {
 
 static int warned_about_invisible_spans = 0; // To avoid a flood of warnings
 
-int zmachine_preserve_zscii = ZSCII_EXTEND; // See backend_z.h for meanings; set by backend.c
+static int preserve_zscii = ZSCII_EXTEND; // See backend_z.h for meanings: EXTEND, DONT_EXTEND, or REPLACE
 
 static uint16_t default_extended_zscii[69] = { // The default mapping, assumed by interpreters that don't support a Unicode translation table (like Ozmoo)
 	// These Unicode chars map to zscii characters 155..223 in order.
@@ -158,7 +158,7 @@ static int nwordtable;
 static struct backend_wobj *backendwobj;
 
 static uint8_t unicode_to_zscii(uint16_t, const char*);
-void prepare_wordseps_z(const uint8_t *wordseps) {
+static void prepare_wordseps(const uint8_t *wordseps) {
 	int i, len = strlen((char*)wordseps); // Overestimate
 	uint16_t unichars[len+1];
 	utf8_to_unicode(unichars, len+1, wordseps);
@@ -169,6 +169,14 @@ void prepare_wordseps_z(const uint8_t *wordseps) {
 		STOPCHARS[i] = unicode_to_zscii(unichars[i], "word separators");
 	}
 	STOPCHARS[i] = 0;
+}
+
+static int optimize_alphabet = 0; // see configure_z
+
+void configure_z(const uint8_t *wordseps, int opt_alpha, int pres_zscii) {
+	optimize_alphabet = opt_alpha;
+	preserve_zscii = pres_zscii;
+	if(wordseps) prepare_wordseps(wordseps);
 }
 
 void set_global_label(uint16_t lab, uint16_t val) {
@@ -291,7 +299,7 @@ uint8_t add_extended_zscii(uint16_t uchar, const char *reason) {
 	uint8_t utf8[5]; // To hold the UTF-16 character converted to UTF-8: up to four bytes plus terminator
 	// Since Z-machine only supports the BMP, really we only need *three* bytes plus terminator, but it's good to think about the future
 	
-	if(zmachine_preserve_zscii == ZSCII_DONT_EXTEND) {
+	if(preserve_zscii == ZSCII_DONT_EXTEND) {
 		unicode_to_utf8_n(utf8, 5, &uchar, 1); // Convert to UTF-8 sequence for error reporting
 		report(LVL_WARN, 0, "Unicode character U+%04x (%s) appeared in %s context, but could not be added due to --basic-zscii. This character will not be recognized by the parser.", uchar, utf8, reason);
 		return ' '; // Will make a word unparseable
@@ -299,7 +307,7 @@ uint8_t add_extended_zscii(uint16_t uchar, const char *reason) {
 	
 	if(n_extended+1 >= EXTENDED_ZSCII_MAX) { // But we can't!
 		unicode_to_utf8_n(utf8, 5, &uchar, 1); // Convert to UTF-8 sequence for error reporting
-		if(zmachine_preserve_zscii == ZSCII_EXTEND) {
+		if(preserve_zscii == ZSCII_EXTEND) {
 			report(LVL_ERR, 0, "Tried to add Unicode character U+%04x (%s) to the encoding, but all codepoints have already been allocated! Use the --no-default-unicode command line option to save space.", uchar, utf8);
 		} else { // ZSCII_REPLACE
 			report(LVL_ERR, 0, "Tried to add Unicode character U+%04x (%s) to the encoding, but all codepoints have already been allocated! Z-machine only supports %d non-ASCII characters in dictionary words.", uchar, utf8, EXTENDED_ZSCII_MAX);
@@ -411,8 +419,7 @@ static int utf8_to_zscii(uint8_t *dest, int ndest, char *src, uint32_t *special,
 }
 
 // Alphabets used for encoding and decoding
-// Default one is used unless zmachine_optimize_alphabet is set
-int zmachine_optimize_alphabet = 0; // Set in frontend.c
+// Default one is used unless optimize_alphabet is set
 #define ALPHABET_LEN (26+26+24)
 #define ALPHABET_OFFSET 6 // first char of each alphabet is actually value 6
 static const uint8_t default_alphabet[] = "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789.,!?_#'\"/\\-:()";
@@ -449,7 +456,7 @@ static void prepare_alphabet() {
 	int i, j, best;
 	memset(alphabet, 0, sizeof(alphabet));
 	
-	if(zmachine_optimize_alphabet) {
+	if(optimize_alphabet) {
 		dict_frequencies[0] = 0; // ZSCII 0 is illegal, but just to be safe
 		for(i = 0; i < ALPHABET_LEN; i++) {
 			// Choose the best character to put in slot i
@@ -973,7 +980,7 @@ void prepare_dictionary_z(struct program *prg) {
 		exit(1);
 	}
 	
-	if(zmachine_preserve_zscii == ZSCII_REPLACE) { // Discard the existing table, giving us the maximum space possible
+	if(preserve_zscii == ZSCII_REPLACE) { // Discard the existing table, giving us the maximum space possible
 		n_extended = 0;
 	} else { // Use the existing table as much as possible, either putting our new characters at the end of it or allowing no new characters at all
 		memcpy(extended_zscii, default_extended_zscii, sizeof(default_extended_zscii));
@@ -4896,7 +4903,7 @@ void backend_z(
 	addr_static = org;
 //	report(LVL_DEBUG, 0, "RAM done:       $%06x", org);
 	
-	if(zmachine_optimize_alphabet) {
+	if(optimize_alphabet) {
 		addr_alphabet = org;
 		org += 3 * 26; // 3 alphabets, 26 chars each
 		used_abbrevs += 3 * 26;
@@ -5060,7 +5067,7 @@ void backend_z(
 	zcore[0x1b] = (filesize / packfactor) & 0xff;
 	//zcore[0x2e] = addr_termchar >> 8;
 	//zcore[0x2f] = addr_termchar & 0xff;
-	if(zmachine_optimize_alphabet) {
+	if(optimize_alphabet) {
 		zcore[0x34] = addr_alphabet >> 8;
 		zcore[0x35] = addr_alphabet & 0xff;
 	}
@@ -5133,7 +5140,7 @@ void backend_z(
 		zcore[addr++] = value & 0xff;
 	}
 	
-	if(zmachine_optimize_alphabet) {
+	if(optimize_alphabet) {
 		// Alphabet table
 		for(i = 0; i < 26; i++) {
 			zcore[addr_alphabet + 0*26 + i] = A0[i];

--- a/src/backend_z.h
+++ b/src/backend_z.h
@@ -1,6 +1,6 @@
 
+void configure_z(const uint8_t *wordseps, int optimize_alphabet, int preserve_zscii);
 void prepare_dictionary_z(struct program *prg);
-void prepare_wordseps_z(const uint8_t *wordseps);
 
 void backend_z(
 	char *filename,

--- a/src/backend_z.h
+++ b/src/backend_z.h
@@ -13,3 +13,7 @@ void backend_z(
 	int strip,
 	struct program *prg,
 	struct arena *arena);
+
+#define ZSCII_EXTEND 0 // Default: add new characters, don't replace any existing ones
+#define ZSCII_DONT_EXTEND 1 // Don't add any new characters
+#define ZSCII_REPLACE 2 // Purge the existing stock and replace them all


### PR DESCRIPTION
This leads to larger files and worse parsing, but improves compatibility with retro interpreters that don't support Unicode translation tables. It shouldn't be needed often, but when it is, it's good to have it.

Also used this opportunity to clean up how configuration variables are passed to backends.