### PR TITLE
Update test cases for new Å bugfix

### DIFF
--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -8,7 +8,7 @@ nav:
 asciidoc:
   attributes:
     lang-ver: 1c
-    lib-ver: 1.2.2
+    lib-ver: 1.2.3
     old-home-page: https://linusakesson.net/dialog/
     home-page: https://github.com/Dialog-IF/dialog/
     aa-old-home-page: https://linusakesson.net/dialog/aamachine/

--- a/readme.txt
+++ b/readme.txt
@@ -43,8 +43,12 @@ Project website:
 
 Release notes:
 
-	1c/02, Lib 1.2.2:
+	1c/02, Lib 1.2.3:
 
+		Library: incredibly trivial changes to make it easier to get
+		identical output across backends. Users are unlikely to ever
+		notice the difference.
+		
 		Compiler: objects produced by (generate $ $) no longer have
 		author-accessible names, which could confuse the compiler.
 		

--- a/stdlib.dg
+++ b/stdlib.dg
@@ -1,5 +1,5 @@
 
-(library version) Library version 1.2.2.
+(library version) Library version 1.2.3.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Global variables
@@ -5185,8 +5185,10 @@
 	(div @gameover) {
 		(space 5)
 		\*\*\* (query $Message) \*\*\*
-		(space 5)
-		%% Why the second (space 5)? So that if someone sets text-align: center for the Å-machine web interpreter, the initial (space 5) won't put it off-center again.
+		(if) (interpreter supports text alignment) (then)
+			(space 5)
+			%% Why the second (space 5)? So that if someone sets text-align: center for the Å-machine web interpreter, the initial (space 5) won't put it off-center again.
+		(endif)
 	}
 	(now) (game has ended)
 	(stop) %% This breaks out of the main game loop to free memory; the fact that (game has ended) then makes the main loop call (game over) to end things properly

--- a/test/6502/6502.gold
+++ b/test/6502/6502.gold
@@ -3778,7 +3778,7 @@ out her dollhouse.
 "Well," you say, "I'm a little old for that." She looks crestfallen, so you grab
 the dollhouse and add, "But don't worry. Let me just run this downstairs."
 
-     *** You have won! ***     
+     *** You have won! ***
 
 Would you like to:
      UNDO the last move,

--- a/test/impossible/aamachine.gold
+++ b/test/impossible/aamachine.gold
@@ -911,6 +911,7 @@ Oh, sweet, it's your favorite: maple and brown sugar.
 
 > x
 (I only understood you as far as wanting to examine something.)
+
 > beans
 Nobody in the house likes yellow wax beans, but, on the other hand, no one wants
 to throw this out. Who knows how old this is now.

--- a/test/impossible/aamachine.gold
+++ b/test/impossible/aamachine.gold
@@ -3778,7 +3778,7 @@ out her dollhouse.
 "Well," you say, "I'm a little old for that." She looks crestfallen, so you grab
 the dollhouse and add, "But don't worry. Let me just run this downstairs."
 
-     *** You have won! ***     
+     *** You have won! ***
 
 Would you like to:
      UNDO the last move,

--- a/test/impossible/debugger.gold
+++ b/test/impossible/debugger.gold
@@ -4351,7 +4351,7 @@ pulls out her dollhouse.
 "Well," you say, "I'm a little old for that." She looks crestfallen, so you
 grab the dollhouse and add, "But don't worry. Let me just run this downstairs."
 
-     *** You have won! ***     
+     *** You have won! ***
 
 Would you like to:
      <UNDO> the last move,

--- a/test/simple/library/man_10a.gold
+++ b/test/simple/library/man_10a.gold
@@ -13,7 +13,7 @@ minute ticks by.
 
 > yodel a folk tune
 (I'm sorry, I didn't understand what you wanted to do.)
-[ZD]
+
 > play
 Play what?
 
@@ -40,13 +40,13 @@ You set the bow to the violin and begin to play. Another minute ticks by.
 
 > play spiccato with bow
 (I only understood you as far as wanting to play something with the bow.)
-[ZD]
+
 > hint
 Try yodeling a lot.
 
 > play bugs
 (I only understood you as far as wanting to play something.)
-[ZD]
+
 > complain about violin
 You can't complain about the violin. Another minute ticks by.
 
@@ -61,7 +61,7 @@ You can't complain about your childhood on planet Zyx. Another minute ticks by.
 
 > complain
 (I'm sorry, I didn't understand what you wanted to do.)
-[ZD]
+
 > cast xyzzy
 With great gravitas, you intone the mystic word " xyzzy ". Another minute ticks
 by.
@@ -72,5 +72,5 @@ by.
 
 > cast violin
 (I'm sorry, I didn't understand what you wanted to do.)
-[ZD]
+
 >

--- a/test/simple/library/man_11a.gold
+++ b/test/simple/library/man_11a.gold
@@ -25,5 +25,5 @@ Location
 
 > x it
 Did you want to examine the small safe or the pearl necklace?
-[ZD]
+
 >

--- a/test/simple/library/man_11b.gold
+++ b/test/simple/library/man_11b.gold
@@ -8,7 +8,7 @@ This is a very nondescript room, dominated by a wooden table.
 
 > take two marbles
 (I only understood you as far as wanting to take something.)
-[ZD]
+
 > open boxes
 The closed box on the wooden table: You open the box, revealing two marbles.
 
@@ -40,7 +40,7 @@ Did you want to:
 1. eat a marble, or
 2. eat a marble that's in the open box on the wooden table?
 (Type the corresponding number)
-[ZD]
+
 > eat a marble
 (first attempting to take the marble)
 You take the marble.
@@ -52,5 +52,5 @@ Did you want to:
 1. put the marble on the wooden table, or
 2. put a marble that's in the open box on the wooden table on the wooden table?
 (Type the corresponding number)
-[ZD]
+
 >

--- a/test/simple/library/man_11c.gold
+++ b/test/simple/library/man_11c.gold
@@ -8,7 +8,7 @@ This is a very nondescript room, dominated by a wooden table.
 
 > take two marbles
 (I only understood you as far as wanting to take something.)
-[ZD]
+
 > open boxes
 The closed box on the wooden table: You open the box, revealing a marble and a
 marble.
@@ -41,7 +41,7 @@ The marble that's held by yourself: The marble falls to the ground.
 Did you want to eat the marble, the marble that's in the open box on the wooden
 table, the marble that's in the open box on the wooden table, the marble that's
 in the open box on the wooden table, or the marble?
-[ZD]
+
 > eat a marble
 (first attempting to take the marble)
 You take the marble.
@@ -52,5 +52,5 @@ You eat the marble.
 Did you want to put the marble, the marble that's in the open box on the wooden
 table, the marble that's in the open box on the wooden table, or the marble
 that's in the open box on the wooden table on the wooden table?
-[ZD]
+
 >

--- a/test/simple/library/man_1a.gold
+++ b/test/simple/library/man_1a.gold
@@ -29,4 +29,4 @@ You enjoy a bit of jumping on the spot.
 Really quit? (y/n)
 > y
 Thanks for playing!
-[ZD]
+

--- a/test/simple/library/man_2a.gold
+++ b/test/simple/library/man_2a.gold
@@ -28,7 +28,7 @@ It's white and made of plastic.
 
 > sit on wooden
 (I only understood you as far as wanting to get onto something.)
-[ZD]
+
 > stand
 You get off the chair.
 

--- a/test/simple/library/man_2b.gold
+++ b/test/simple/library/man_2b.gold
@@ -1,8 +1,7 @@
 Pandora looks at her box. The box is closed. She looks away for five seconds,
 and then looks at it again, just to check. The box is open.
 
-[Z]      *** That's just life. ***
-[DA]      *** That's just life. ***    
+     *** That's just life. ***
 
 Would you like to:
      UNDO the last move,

--- a/test/simple/library/man_2c.gold
+++ b/test/simple/library/man_2c.gold
@@ -8,7 +8,7 @@ You are here.
 
 > x red
 Did you want to examine the red bottle or the red bottle cap?
-[ZD]
+
 > x red bottle
 It seems to be harmless.
 

--- a/test/simple/library/man_3a.gold
+++ b/test/simple/library/man_3a.gold
@@ -11,7 +11,7 @@ On the wooden table you find a green apple, a blueberry, and a dark red cherry.
 
 > eat berry
 Did you want to eat the blueberry or the dark red cherry?
-[ZD]
+
 > blueberry
 You eat the blueberry.
 

--- a/test/simple/library/man_4a.gold
+++ b/test/simple/library/man_4a.gold
@@ -33,7 +33,7 @@ The sapphire: You take the sapphire out of the small bowl.
 
 > put stone in bowl
 Did you want to put the sapphire or the amethyst in the small bowl?
-[ZD]
+
 > amethyst
 You put the amethyst in the small bowl.
 

--- a/test/simple/library/man_5a.gold
+++ b/test/simple/library/man_5a.gold
@@ -65,8 +65,7 @@ You walk south through the small door.
 Professor Stroopwafel's study
 You solved the mystery of the locked door!
 
-[Z]      *** You win! ***
-[DA]      *** You win! ***    
+     *** You win! ***
 
 Would you like to:
      UNDO the last move,

--- a/test/simple/library/man_8a.gold
+++ b/test/simple/library/man_8a.gold
@@ -12,8 +12,7 @@ You take the apple.
 
 The apple is yummy. You feel that your mission has come to an end.
 
-[Z]      *** You are no longer hungry. ***
-[DA]      *** You are no longer hungry. ***    
+     *** You are no longer hungry. ***
 
 Would you like to:
      UNDO the last move,
@@ -47,4 +46,4 @@ Would you like to:
      or RESTART from the beginning?
 > quit
 Thanks for playing!
-[ZD]
+

--- a/test/simple/library/man_9c.gold
+++ b/test/simple/library/man_9c.gold
@@ -46,7 +46,7 @@ Lisa rifles through a box of parts.
 
 > x mechanic
 (I only understood you as far as wanting to examine something.)
-[ZD]
+
 > x lisa
 She seems to be harmless.
 

--- a/test/simple/library/man_9c.gold
+++ b/test/simple/library/man_9c.gold
@@ -108,8 +108,7 @@ Thursday.”
 
 Lisa nods, and you walk out into the rain.
 
-[Z]      *** You have no car. ***
-[DA]      *** You have no car. ***    
+     *** You have no car. ***
 
 Would you like to:
      UNDO the last move,
@@ -118,4 +117,4 @@ Would you like to:
      or RESTART from the beginning?
 > quit
 Thanks for playing!
-[ZD]
+

--- a/test/simple/library/new_ambigplural.gold
+++ b/test/simple/library/new_ambigplural.gold
@@ -13,7 +13,7 @@ It seems to be harmless.
 "Me" refers to yourself.
 "It" refers to the deck of cards.
 "Them" refers to the deck of cards.
-[ZD]
+
 > x box
 It seems to be harmless.
 
@@ -21,7 +21,7 @@ It seems to be harmless.
 "Me" refers to yourself.
 "It" refers to the box.
 "Them" refers to the deck of cards.
-[ZD]
+
 > x candy
 They seem to be harmless.
 
@@ -29,5 +29,5 @@ They seem to be harmless.
 "Me" refers to yourself.
 "It" refers to the candy.
 "Them" refers to the candy.
-[ZD]
+
 >

--- a/test/simple/library/new_longdistance.gold
+++ b/test/simple/library/new_longdistance.gold
@@ -24,15 +24,15 @@ You see a shiny treasure here.
 (northeast)
 
 Delta
-[ZD]
+
 (east)
 
 Alpha
-[ZD]
+
 (north)
 
 Beta
-[ZD]
+
 (north)
 
 Zeta
@@ -49,11 +49,11 @@ You take the shiny treasure.
 (northeast)
 
 Delta
-[ZD]
+
 (east)
 
 Alpha
-[ZD]
+
 A mysterious force prevents you from passing!
 
 Because something dramatic happened, your movement was cut short.
@@ -65,11 +65,11 @@ Epsilon
 (northeast)
 
 Delta
-[ZD]
+
 (east)
 
 Alpha
-[ZD]
+
 A mysterious force prevents you from passing!
 
 Because something dramatic happened, your movement was cut short.

--- a/test/simple/library/new_longdistance2.gold
+++ b/test/simple/library/new_longdistance2.gold
@@ -10,7 +10,7 @@ This is room alpha.
 (north)
 
 Beta
-[ZD]
+
 (north)
 
 Zeta
@@ -20,15 +20,15 @@ This is room zeta.
 (south)
 
 Beta
-[ZD]
+
 (south)
 
 Alpha
-[ZD]
+
 (west)
 
 Delta
-[ZD]
+
 (southwest)
 
 Epsilon

--- a/test/simple/library/new_verbosity.gold
+++ b/test/simple/library/new_verbosity.gold
@@ -11,12 +11,12 @@ is a forest.
 You walk east.
 
 Well house
-[ZD]
+
 > w
 You walk west.
 
 End of the road
-[ZD]
+
 > undo
 Undoing the last turn (w).
 Well house
@@ -28,7 +28,7 @@ End of the road
 > brief
 An Interactive Fiction is now in BRIEF mode. Location details will not be shown
 when moving to a previously-visited area.
-[ZD]
+
 > e
 You walk east.
 
@@ -40,7 +40,7 @@ north.
 You walk west.
 
 End of the road
-[ZD]
+
 > look
 End of the road
 You are standing at the end of a road before a small brick building. Around you
@@ -61,7 +61,7 @@ End of the road
 > verbose
 An Interactive Fiction is now in VERBOSE mode. Location details will not be
 shown when travelling long distances, but will be shown after normal movement.
-[ZD]
+
 > e
 You walk east.
 
@@ -79,7 +79,7 @@ You are in open forest, with a deep valley to one side.
 (south)
 
 Well house
-[ZD]
+
 (west)
 
 End of the road
@@ -101,7 +101,7 @@ End of the road
 > superverbose
 An Interactive Fiction is now in SUPERVERBOSE mode. Location details will always
 be shown when moving.
-[ZD]
+
 > e
 You walk east.
 


### PR DESCRIPTION
The Å-machine previously had a bug involving paragraph breaks after divs, and our test cases were written to accommodate that. Now the bug is fixed. This PR updates the test cases to no longer expect the old (bad) behavior.