### PR TITLE
Ensure (stop) inside (collect words) does not break the debugger

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2530,6 +2530,9 @@ static int eval_run(struct eval_state *es) {
 				if(ci->oper[i].tag == OPER_WORD) {
 					w = es->program->allwords[ci->oper[i].value];
 					if(es->forwords) {
+						if(!(w->flags & WORDF_DICT)) {
+							report(LVL_ERR, 0, "Word '%s' does not have the dictionary flag set, but it was produced by a (collect words)", w->name);
+						}
 						assert(w->flags & WORDF_DICT);
 						if(!push_aux(es, (value_t) {VAL_DICT, w->dict_id})) {
 							pred_release(pp.pred);


### PR DESCRIPTION
See issue #317 . A `(stop)` inside a `(collect words)` leaves CWL set in the debugger, but not on Z-machine or Å-machine. What's different in the debugger? Its behavior seems to be following the Å-machine spec…