### PR TITLE
Build universal (arm64+x86_64) macOS binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         run: make test
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-arm64
+          name: macos-universal
           path: |
             src/dgdebug
             src/dialogc
@@ -119,7 +119,7 @@ jobs:
           # Create the bundle and add the prebuild binaries in
           mkdir -p "$BUNDLE/prebuilt"
           mv artifacts/linux-x86_64 "$BUNDLE/prebuilt/"
-          mv artifacts/macos-arm64 "$BUNDLE/prebuilt/"
+          mv artifacts/macos-universal "$BUNDLE/prebuilt/"
           mv artifacts/win32 "$BUNDLE/prebuilt/"
           chmod +x "$BUNDLE"/prebuilt/*/*
           # Include all the other relevant files from the release

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,12 @@ WINLIB		= ../prebuilt/win32
 MINGW32		= i686-w64-mingw32-gcc
 WINDRES		= i686-w64-mingw32-windres
 
+UNAME_S		:= $(shell uname -s)
+ifeq (${UNAME_S},Darwin)
+CFLAGS		+= -arch arm64 -arch x86_64
+LDFLAGS		+= -arch arm64 -arch x86_64
+endif
+
 INSTALLDIR	= /usr/local/bin
 
 all:			dialogc dgdebug


### PR DESCRIPTION
## Summary
- Build dialogc/dgdebug as fat binaries on macOS by passing `-arch arm64 -arch x86_64` in CFLAGS/LDFLAGS when `uname -s` is Darwin, leaving Linux and the mingw cross-builds untouched.
- Rename the macOS CI artifact from `macos-arm64` to `macos-universal` to reflect the change (both the upload step and the release-bundling step).

Closes #330

## Test plan
- [x] `make --directory=./src clean all` on macOS (Apple Silicon) and confirmed `lipo -info` reports both `x86_64` and `arm64` for `dialogc` and `dgdebug`
- [x] CI: `build-macos` job builds and `make test` passes with the universal binaries