### PR TITLE
docs: add under the hood docs

### DIFF
--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -5,6 +5,7 @@ nav:
   - modules/ROOT/nav.adoc
   - modules/lang/nav.adoc
   - modules/lib/nav.adoc
+  - modules/internals/nav.adoc
 asciidoc:
   attributes:
     lang-ver: 1c

--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -63,5 +63,15 @@ xref:lib:testing.adoc[]
 
 xref:lib:libref.adoc[]
 
+== Part III: Under the Hood
+
+xref:internals:overview.adoc[]
+
+xref:internals:parsing.adoc[]
+
+xref:internals:rulesengine.adoc[]
+
+xref:internals:zcode.adoc[]
+
 '''
 

--- a/manual/modules/internals/nav.adoc
+++ b/manual/modules/internals/nav.adoc
@@ -1,0 +1,5 @@
+* Under the Hood
+** xref:overview.adoc[Overview]
+** xref:parsing.adoc[Parsing and the AST]
+** xref:rulesengine.adoc[The rules engine and the debugger]
+** xref:zcode.adoc[Compiling to Z-machine code]

--- a/manual/modules/internals/pages/overview.adoc
+++ b/manual/modules/internals/pages/overview.adoc
@@ -17,35 +17,22 @@ Every Dialog source file passes through the same front end, regardless of
 whether you're compiling a story or running it under the debugger. Only the
 very last step differs:
 
-[source]
-----
- source files (.dg)
-        |
-        v
-   lexer + parser  ------------------  one shared abstract syntax tree
-        |                              (terms and goals are the same
-        v                               node type; see xref:parsing.adoc[])
-  frontend passes
-  (macro expansion, dynamic-predicate
-   discovery, dataflow analysis,
-   dictionary construction, ...)
-        |
-        v
-  compile.c: lowering to a flat,
-  backend-neutral bytecode IR
-  (WAM-flavoured: choice points,
-   environments, unification
-   instructions; see xref:zcode.adoc[])
-        |
-        +-------------------+-------------------+
-        v                   v                   v
-    eval.c              backend_z.c         backend_aa.c
-  (dgdebug: runs      (dialogc -t z5/z8/  (dialogc -t aa:
-   the IR directly     zblorb: emits       emits Å-machine
-   as a bytecode VM;    Z-machine code;     bytecode; see
-   see                  see                 xref:zcode.adoc[])
-   xref:rulesengine.adoc[])  xref:zcode.adoc[])
-----
+. *Source files* (`.dg`) are read by the lexer and parser into *one shared
+  abstract syntax tree*, in which terms and goals are just different tags on
+  the same node type. See xref:parsing.adoc[].
+. A long sequence of *frontend passes* walks that tree: macro expansion,
+  dynamic-predicate discovery, boundness/determinism dataflow analysis,
+  dictionary construction, and more. See xref:parsing.adoc[].
+. `compile.c` *lowers the analyzed program* into a flat, backend-neutral
+  bytecode IR — WAM-flavoured, with explicit choice-point, environment, and
+  unification instructions. See xref:zcode.adoc[].
+. That one bytecode IR is then handed to exactly one of three consumers:
+  ** `eval.c`, used by `dgdebug`, executes the IR directly as a bytecode VM.
+     See xref:rulesengine.adoc[].
+  ** `backend_z.c`, used by `dialogc -t z5`/`z8`/`zblorb`, translates the IR
+     into Z-machine code. See xref:zcode.adoc[].
+  ** `backend_aa.c`, used by `dialogc -t aa`, translates the same IR into
+     Å-machine bytecode instead. See xref:zcode.adoc[].
 
 The key idea that ties the rest of this part together is that **the debugger
 and the compiler are not two separate implementations of Dialog** — they are

--- a/manual/modules/internals/pages/overview.adoc
+++ b/manual/modules/internals/pages/overview.adoc
@@ -1,0 +1,96 @@
+= Overview
+
+This part of the manual is different from the rest. Part I and Part II describe
+the Dialog language and standard library from the point of view of someone
+writing a game. This part instead describes how the Dialog tools themselves are
+built: how `dialogc` and `dgdebug` turn a handful of `.dg` source files into
+either a running game or a story file. It's aimed at anyone curious about the
+implementation, and at contributors working on the C source in `src/`.
+
+Nothing here changes how you write Dialog code, and none of it is required
+reading in order to use the language. Read on if you'd like to know what
+happens after you type `dialogc story.dg stdlib.dg`.
+
+== The shape of the pipeline
+
+Every Dialog source file passes through the same front end, regardless of
+whether you're compiling a story or running it under the debugger. Only the
+very last step differs:
+
+[source]
+----
+ source files (.dg)
+        |
+        v
+   lexer + parser  ------------------  one shared abstract syntax tree
+        |                              (terms and goals are the same
+        v                               node type; see xref:parsing.adoc[])
+  frontend passes
+  (macro expansion, dynamic-predicate
+   discovery, dataflow analysis,
+   dictionary construction, ...)
+        |
+        v
+  compile.c: lowering to a flat,
+  backend-neutral bytecode IR
+  (WAM-flavoured: choice points,
+   environments, unification
+   instructions; see xref:zcode.adoc[])
+        |
+        +-------------------+-------------------+
+        v                   v                   v
+    eval.c              backend_z.c         backend_aa.c
+  (dgdebug: runs      (dialogc -t z5/z8/  (dialogc -t aa:
+   the IR directly     zblorb: emits       emits Å-machine
+   as a bytecode VM;    Z-machine code;     bytecode; see
+   see                  see                 xref:zcode.adoc[])
+   xref:rulesengine.adoc[])  xref:zcode.adoc[])
+----
+
+The key idea that ties the rest of this part together is that **the debugger
+and the compiler are not two separate implementations of Dialog** — they are
+two different consumers of one shared intermediate representation. `compile.c`
+lowers your program into a flat array of instructions once; `eval.c` executes
+that array directly (with a Prolog-style choice-point stack living in ordinary
+C data structures), while `backend_z.c` and `backend_aa.c` each translate the
+very same array into a different target machine's native code. This is why the
+debugger's behaviour (aside from performance, and a few explicitly documented
+differences noted in xref:ROOT:software.adoc#dgdebug[the user-facing debugger
+section]) tracks the compiled game so closely: it's running the same compiled
+logic, just on a more forgiving virtual machine.
+
+== What each page covers
+
+xref:parsing.adoc[]::
+How source text becomes a program: the lexer's handling of Dialog's sigils
+(`$`, `#`, `@`, `~`, `*`, and bracket types), how every distinct word is
+interned once, and how the parser builds a single unified syntax tree in which
+terms and goals are just different tags on the same node type. Also covers how
+a predicate's identity is its whole head word-pattern (not just a name and
+arity), why there's no textual `#include` mechanism, and how the `@(...)`
+access-predicate facility implements Dialog's macro system as a structural,
+compile-time AST rewrite.
+
+xref:rulesengine.adoc[]::
+The reference interpreter's execution engine: a small stack-based bytecode
+machine directly descended from the WAM
+(https://en.wikipedia.org/wiki/Warren_Abstract_Machine[Warren Abstract Machine])
+used to implement Prolog. Covers the tagged-value heap, unification, the trail-based
+undo mechanism that makes backtracking possible, choice points and
+environments, how cut and Dialog's default "query succeeds at most once"
+semantics are compiled, and the `(collect)` aggregate mechanism. Also covers
+how `dgdebug` is built on top of this engine — in particular, how the very
+same engine is reused, without any dynamic game state attached, purely to
+compute the default values of dynamic predicates at compile time.
+
+xref:zcode.adoc[]::
+How the same compiled program becomes a Z-machine story file. Covers the
+shape of the intermediate bytecode itself, how clause unification and
+first-argument indexing are compiled into explicit instructions, how
+Prolog-style backtracking is realized using nothing but the Z-machine's own
+global variables, dynamic memory, and `catch`/`throw`, and how Dialog's
+dynamic predicates (the things you change with `(now)`) end up as Z-machine
+object attributes, property-like arrays, or the native object tree, depending
+on their shape. Closes with a look at the Å-machine backend, which targets a
+completely different virtual machine from the exact same intermediate
+representation.

--- a/manual/modules/internals/pages/parsing.adoc
+++ b/manual/modules/internals/pages/parsing.adoc
@@ -31,7 +31,81 @@ by the whole program. From then on, that piece of text is represented by a
 pointer to one `struct word`, not by repeated string comparisons. This is what
 lets later passes attach flags (is this word ever used as a dictionary word?
 as an output word? as the current "topic"?) and small dense integer IDs
-directly to the word itself.
+directly to the word itself:
+
+[source,c]
+----
+struct word {
+	struct word		*next_in_hash;
+	char			*name;
+	unsigned int		flags:4;	// WORDF_DICT, WORDF_TAG, WORDF_OUTPUT, WORDF_TOPIC
+	unsigned int		word_id:28;
+	uint16_t		obj_id;		// nonzero if this word also names a #tag object
+	uint16_t		dict_id;	// nonzero if this word is also a @dictionary word
+};
+----
+
+There's exactly one of these per distinct spelling, program-wide, ever. A
+variable named `$Foo` in one clause and `$Foo` in a completely different
+clause in a different file are two unrelated variables at the language level,
+of course, but the *word* `Foo` — the three-letter spelling — is the same
+interned `struct word` in both places; it's the surrounding `AN_VARIABLE`
+node (one per occurrence, see below) that gives each mention its own
+identity. The same interned word can simultaneously be a `#tag` (carrying a
+nonzero `obj_id`) and a `@dictionary` word (carrying a nonzero `dict_id`),
+since nothing stops a story from using the same spelling for both.
+
+=== The lexer's own state
+
+The lexer itself is a single `struct lexer`, threaded through every call to
+the tokenizer and the recursive-descent parser built on top of it:
+
+[source,c]
+----
+struct lexer {
+	struct program		*program;
+	FILE			*file;		// the source file being read, or...
+	const uint8_t		*string;	// ...a string, for an interactively injected query
+	uint8_t			kind;		// TOK_* -- the current token's kind
+	struct word		*word;		// the current token's interned word, if any
+	int			value;		// the current token's integer value, if any
+	struct arena		temp_arena;	// transient, per-file AST allocation
+	uint32_t		wordcount;
+	uint32_t		totallines;
+	uint32_t		totalwords;
+	int			errorflag;
+	int			lib_file;	// did this file declare (library version ...)?
+	// ...
+};
+----
+
+The `kind` field is one of a small, flat enum of token kinds. Values below
+128 are just the ASCII code of a single-character token (`(`, `)`, `[`, `]`,
+`{`, `}`, `~`, `*`); values from 128 up name the multi-character kinds:
+
+[source,c]
+----
+enum {
+	TOK_BAREWORD = 128,
+	TOK_DICTWORD,
+	TOK_TAG,
+	TOK_VARIABLE,
+	TOK_INTEGER,
+	TOK_STARPAREN,	// the two-character token "*("
+	TOK_NOSPACE
+};
+----
+
+Two things are worth noticing about this design. First, there's no separate
+token *string* buffer to manage: by the time a token has a `kind` of
+`TOK_VARIABLE`, `TOK_TAG`, `TOK_DICTWORD`, or `TOK_BAREWORD`, its text has
+already been interned, and `lexer->word` already points at the shared
+`struct word` described above — tokenizing and interning happen in the same
+step. Second, `struct lexer` doubles as the parser's only piece of mutable
+state; the recursive-descent functions described below don't thread a
+separate "current position" cursor around, they just keep calling the
+tokenizer and inspecting `lexer->kind`/`lexer->word`/`lexer->value` as they
+go.
 
 == One node type for both terms and goals
 
@@ -48,6 +122,39 @@ distinguishes a term from a goal is purely which *kind* tag the node carries:
   negated), blocks (`{...}`), disjunction (`(or)`), and the various special
   forms described elsewhere in this manual, such as xref:lang:control.adoc[]'s
   `(if)` and `(select)`, and xref:lang:choicepoints.adoc[]'s `(collect)`.
+
+Concretely, every one of those is a `struct astnode`:
+
+[source,c]
+----
+struct astnode {
+	uint8_t			kind;		// AN_* -- what this node is
+	uint8_t			subkind;	// e.g. a plain vs. multi-query rule call
+	uint16_t		nchild;
+	line_t			line;
+	struct astnode		**children;
+	struct astnode		*next_in_body;	// the next goal in a conjunction
+
+	struct word		*word;		// for AN_VARIABLE / AN_TAG / AN_BAREWORD / AN_DICTWORD
+	int			value;		// for AN_INTEGER
+	struct predname		*predicate;	// for AN_RULE / AN_NEG_RULE
+
+	uint8_t			unbound;	// filled in by later dataflow analysis
+};
+----
+
+The `kind` field is one value from a single flat enum shared by every kind of
+node, terms and goals alike — `AN_VARIABLE`, `AN_TAG`, `AN_INTEGER`,
+`AN_BAREWORD`, `AN_DICTWORD`, `AN_PAIR`, `AN_EMPTY_LIST` for terms;
+`AN_RULE`, `AN_NEG_RULE`, `AN_BLOCK`, `AN_NEG_BLOCK`, `AN_OR`, `AN_IF`,
+`AN_SELECT`, `AN_COLLECT`, and so on for goals. `children` holds a node's
+sub-terms (a variable or tag has none; a pair has a head and a tail; a rule
+call has one entry per parameter), while `next_in_body` is a completely
+separate link, used only by goal nodes, threading them together into the
+straight-line sequence that makes up a clause body or a block. A predicate
+call's identity isn't stored as a word or a name at all — it's a direct
+pointer, `predicate`, at the shared `struct predname` record described below,
+found once during parsing and never looked up by name again afterwards.
 
 A conjunction — a straight-line sequence of goals in a rule body — is simply
 a linked chain of goal nodes. A disjunction is represented explicitly, as a
@@ -78,10 +185,37 @@ predicate's name.
 
 Every predicate that's ever mentioned, in a rule head or in a query, is
 resolved to one shared, permanent record the first time it's seen, and every
-subsequent mention (in any source file) finds that same record. This is also
-how a predicate can be safely redefined while `dgdebug` is running with edited
-source: the old implementation is kept around just long enough to let
-persistent state (such as `(select)` counters) carry over to the new one.
+subsequent mention (in any source file) finds that same record:
+
+[source,c]
+----
+struct predname {
+	uint16_t		pred_id;
+	uint16_t		arity;
+	uint16_t		nword;
+	struct word		**words;	// a null entry marks a parameter position
+	char			*printed_name;	// for diagnostics
+	struct predicate	*pred;		// the current implementation
+	struct predicate	*old_pred;	// the previous one, kept for (select) recovery
+	uint16_t		special;	// nonzero for SP_* forms like (if) or (select)
+	uint16_t		builtin;	// nonzero for BI_* builtins like (now) or (fail)
+	uint16_t		dyn_id;		// slot among global/per-object flags, if dynamic
+	// ...
+};
+----
+
+The `words` array *is* the predicate's identity: it's the rule head's literal
+words in order, with a null entry standing in for each parameter position, so
+that matching a call site against this array is exactly how the parser (and
+later, the compiler) decides which predicate a given piece of syntax refers
+to. `pred` points at the predicate's actual, current list of clauses (a
+`struct predicate`, holding `clauses[]` plus a large flags word recording
+everything later passes discover about it: whether it's dynamic, whether it's
+ever invoked as a {multi-query}, whether it always succeeds, and so on); when
+`dgdebug` reloads edited source and rebuilds a predicate from scratch, the
+*previous* `struct predicate` is kept around, unreferenced, just long enough
+for state like `(select)` counters to be carried over into the new one before
+being discarded.
 
 == Files, not includes
 

--- a/manual/modules/internals/pages/parsing.adoc
+++ b/manual/modules/internals/pages/parsing.adoc
@@ -1,0 +1,186 @@
+= Parsing and the AST
+
+This page describes how the files you list on the `dialogc`/`dgdebug` command
+line become a single in-memory program, ready for the analysis and compilation
+passes described in the rest of xref:overview.adoc[Under the Hood].
+
+The relevant source files are `src/parse.c`/`src/parse.h` (the lexer and
+recursive-descent reader), `src/ast.c`/`src/ast.h` (the syntax tree and the
+program-wide tables it feeds into), and `src/accesspred.c`/`src/accesspred.h`
+(the `@`-macro expansion facility).
+
+== Tokens and sigils
+
+The lexer recognizes Dialog's small set of prefix sigils directly, stripping
+them and classifying the rest of the word:
+
+* `$Name` becomes a *variable* token.
+* `#name` becomes a *tag* token, and also immediately registers a fresh world
+  object — object identity is handed out at lex time, not later.
+* `@name` becomes a *dictionary word* token (a value the parser can match
+  against player input).
+* A bare word becomes either a printed *bareword* or, inside a value context
+  such as a list, a dictionary word.
+* `(`, `)`, `[`, `]`, `{`, `}`, `~`, and `*(` are returned as their own token
+  kinds and drive the recursive-descent grammar described below.
+* `%%` starts a line comment.
+
+Every distinct piece of source text — every variable name, tag, dictionary
+word, and bareword — is interned exactly once into a single hash table shared
+by the whole program. From then on, that piece of text is represented by a
+pointer to one `struct word`, not by repeated string comparisons. This is what
+lets later passes attach flags (is this word ever used as a dictionary word?
+as an output word? as the current "topic"?) and small dense integer IDs
+directly to the word itself.
+
+== One node type for both terms and goals
+
+Unlike compilers that keep a separate "term" representation for data and a
+"goal" representation for things that get executed, Dialog's parser builds
+everything — variables, tags, integers, lists, predicate calls, negation,
+`if`/`then`, `select`, `collect`, and so on — out of a single node type. What
+distinguishes a term from a goal is purely which *kind* tag the node carries:
+
+* *Terms* (things that appear as arguments): variables, tags, integers,
+  barewords, dictionary words, and list cells (built as a chain of pair nodes,
+  exactly like a Prolog list, terminated by an empty-list node).
+* *Goals* (things that appear in a rule body): predicate calls (positive and
+  negated), blocks (`{...}`), disjunction (`(or)`), and the various special
+  forms described elsewhere in this manual, such as xref:lang:control.adoc[]'s
+  `(if)` and `(select)`, and xref:lang:choicepoints.adoc[]'s `(collect)`.
+
+A conjunction — a straight-line sequence of goals in a rule body — is simply
+a linked chain of goal nodes. A disjunction is represented explicitly, as a
+node with two such chains as its two children. Because terms and goals share
+one node type, the same generic tree-walking code (copying a node, comparing
+two nodes for structural equality, substituting a variable) works uniformly
+across both, which turns out to be essential for the macro-expansion mechanism
+described below.
+
+`{...}` is a good example of how much a Dialog node's meaning depends on
+context: written where a goal is expected, it's just a scoping block. Written
+where a value is expected, the very same braces instead introduce a *closure
+literal* — its body is parsed once, and (after being deduplicated against any
+structurally identical closure already seen) it's turned into a value that,
+later, can be invoked through a single hidden predicate shared by every
+closure in the program.
+
+== Predicates are identified by their whole word pattern
+
+A Dialog predicate's identity isn't a name-plus-arity pair the way it would be
+in most other languages. It's the *entire* fixed sequence of literal words in
+the rule head, with parameter positions marked out. `(the $ is in the $)` and
+`(the $ is on the $)` are two completely different predicates, each with their
+own clause list, even though a name-and-arity scheme would conflate them. This
+is also why Dialog rule heads read like natural-language sentences with blanks
+in them: the literal words aren't just for readability, they *are* the
+predicate's name.
+
+Every predicate that's ever mentioned, in a rule head or in a query, is
+resolved to one shared, permanent record the first time it's seen, and every
+subsequent mention (in any source file) finds that same record. This is also
+how a predicate can be safely redefined while `dgdebug` is running with edited
+source: the old implementation is kept around just long enough to let
+persistent state (such as `(select)` counters) carry over to the new one.
+
+== Files, not includes
+
+There is no textual `#include` directive in Dialog. Instead, every filename
+given on the command line is parsed in turn, and every file's clauses are
+appended to one single, shared, program-wide clause list. Predicate lookup,
+the word table, and the object registry are all shared across every file from
+the very first line of the very first file onward — there's no per-file
+scoping to think about. The only file-order rule the compiler enforces is a
+sanity check: it expects to find a `(library version ...)` declaration, and
+warns if that file isn't listed last, since that's almost always a sign the
+standard library was accidentally passed before the story that depends on it.
+
+== Macros: access predicates
+
+Dialog's macro facility, written `@name(...)`, is not a token-level
+text-substitution preprocessor. It works entirely on the syntax tree that's
+already been built, which is why it can do things a text preprocessor
+couldn't, such as making sure a macro expansion never accidentally captures a
+variable from its call site.
+
+An access-predicate definition looks like an ordinary rule, but is introduced
+with `@` instead of a bare `(`. Defining one this way, rather than as an
+ordinary predicate, tells the compiler two things: first, that calls to it
+should be expanded away entirely rather than compiled as a real predicate
+call, and second, that its head arguments are *patterns* to be matched
+structurally against the actual argument syntax at each call site, not
+run-time values to be unified. A predicate can have several such definitions;
+the first one whose pattern structurally matches the call site's arguments is
+used.
+
+Expanding a use of an access predicate means:
+
+. Finding the first definition whose argument patterns match the call site.
+. Binding each pattern variable to the actual syntax tree passed at the call
+  site.
+. Copying the macro's body, substituting each bound variable with (a fresh
+  copy of) what it's bound to.
+. Renaming every *other* variable in the body — the macro's own local
+  helper variables — to a fresh name, so that using the same macro twice
+  in one clause can never make its internal variables collide.
+
+This expansion happens as one of the first steps of the frontend's analysis
+pipeline, described next, well before any dataflow analysis or compilation
+takes place, so from that point onward the rest of the compiler never needs to
+know that access predicates exist at all — it only ever sees ordinary rule
+calls.
+
+== From syntax tree to annotated program
+
+Building the syntax tree is only the first half of what happens before a
+program is ready to compile. The bulk of `src/frontend.c` is a long, ordered
+sequence of whole-program passes over that tree, each adding information that
+later passes (and, eventually, `compile.c`) depend on. A few of the more
+consequential ones:
+
+Macro and directive expansion::
+Besides expanding `@(...)` access predicates (above), this pass also expands
+a handful of other clause-level directives into ordinary clauses: `(global
+variable ...)` declarations, `(generate N of ...)` object generation, resource
+declarations, and `(interface ...)` mode declarations.
+
+Dynamic-predicate discovery::
+Every use of `(now) (...)` in the program is scanned to find out which
+predicates are ever the target of a state change. A predicate that's never
+targeted by `(now)` is an ordinary set of logical rules; one that is becomes a
+*dynamic predicate* — a piece of mutable state — and is assigned a slot
+among the program's global flags, global variables, per-object flags, or
+per-object variables, depending on its arity. This distinction matters a
+great deal to the backends: see xref:zcode.adoc[] for how each kind of
+dynamic predicate ends up represented in a compiled story.
+
+Boundness and determinism analysis::
+A whole-program, fixed-point dataflow pass figures out, for every argument of
+every predicate, whether it can be unbound (an output) or is always bound (an
+input) at every place the predicate is called, and whether the predicate is
+ever called as a backtracking multi-query as opposed to a plain query. This is
+also where the compiler checks any `(interface ...)` declarations you've
+written against how a predicate is actually used, and where several "did you
+mean to do that?" warnings come from — a predicate that's defined but never
+queried, or queried but never defined, and so on.
+
+Dictionary construction::
+Every literal word that could plausibly appear as player input — every
+`@word` and, in the right context, every plain word — is collected into the
+program's dictionary, ready for the parser (the in-game parser, not the
+compiler!) to match against typed commands.
+
+Fixed-flag and success/failure propagation::
+Several smaller passes look for predicates whose behaviour can be pinned down
+statically: a one-argument dynamic predicate whose rules only ever test a
+fixed, known set of objects can be compiled down to a compact per-object bit
+instead of a general dynamic-predicate lookup; a predicate that's provably
+guaranteed to succeed, or provably guaranteed to fail, lets later dead-code
+elimination remove clauses that can never be reached.
+
+Only once every clause has passed through all of these passes does the
+compiler hand the fully annotated program over to `compile.c`, which is where
+xref:zcode.adoc[the next page but one] picks up the story. In between, the
+program is executable in one more sense first: it can be run directly, one
+compiled instruction at a time, which is what xref:rulesengine.adoc[the rules
+engine] does.

--- a/manual/modules/internals/pages/rulesengine.adoc
+++ b/manual/modules/internals/pages/rulesengine.adoc
@@ -71,6 +71,36 @@ Two explicit stacks carry the engine's control state:
   environment stack, so that retrying can cleanly undo everything that
   happened since.
 
+In `eval.c` these are ordinary C structs, held in two growable arrays
+(`es->envstack` and `es->choicestack`):
+
+[source,c]
+----
+struct env {
+	value_t			*vars;		// this clause activation's local variables
+	value_t			*tracevars;	// a copy of the head args, kept only for readable traces
+	prgpoint_t		cont;		// where to resume once the clause body succeeds
+	uint16_t		env;		// index of the enclosing environment
+	uint16_t		simple;
+};
+
+struct choice {
+	uint16_t		env;		// environment-stack watermark to restore
+	uint16_t		trail;		// trail watermark to undo back to
+	uint16_t		top;		// heap watermark to reclaim back to
+	uint16_t		simple;
+	value_t			arg[MAXPARAM + 1];	// the call's arguments, as they were at this point
+	prgpoint_t		cont;		// where to resume on success
+	prgpoint_t		nextcase;	// where to resume on failure -- the next clause to try
+};
+----
+
+Every field earns its keep at the moment of backtracking: retrying an
+alternative means resetting the trail down to `trail`, the heap down to
+`top`, and the environment stack down to `env`, then jumping to whatever
+`nextcase` says is the next thing to try. There's no search or bookkeeping
+beyond restoring these four numbers and jumping.
+
 Compiling a predicate with several matching clauses means, in the simple
 case, pushing a choice point before trying the first clause (naming the next
 clause as what to retry on failure), and popping it once a later clause
@@ -169,3 +199,108 @@ Breakpoints and query tracing are themselves just two more kinds of compiled
 instruction, carrying the source file and line number they came from, so that
 messages printed while running under `dgdebug` can always point back at a
 specific place in your source code.
+
+== The same machine, compiled: `eval.c` versus the Z-machine
+
+Everything on this page so far — the tagged heap, the trail, environments,
+choice points, cut, the simple/multi distinction — is described here in
+terms of `eval.c`'s own C structs, because that's the easiest place to see the
+mechanism laid bare. But none of it is specific to being interpreted. When
+`dialogc` compiles the very same program for the Z-machine
+(xref:zcode.adoc[]), it builds *exactly the same machine* again, field for
+field, entirely out of Z-machine primitives: ordinary global variables and a
+region of dynamic memory, with no interpreter and no C structs anywhere in
+sight.
+
+The correspondence is close enough to lay out side by side. `eval.c` keeps a
+current environment and a current choice point as C struct pointers; the
+compiled Z-machine story keeps the same two things as *addresses stored in
+two reserved global variables*, `REG_ENV` and `REG_CHOICE`, pointing into a
+region of dynamic memory instead of the process heap:
+
+[cols="1,1,3"]
+|===
+| `eval.c` (`struct env`) | Compiled Z-machine (`ENV_*` record) | Meaning
+
+| `env` (index of enclosing frame)
+| `ENV_ENV`
+| the environment to restore control to once this one is deallocated
+
+| `cont`
+| `ENV_CONT`
+| where to resume once this clause's body succeeds
+
+| `simple`
+| `ENV_SIMPLE`
+| whether this call was made as a plain (at-most-one-answer) query
+|===
+
+[cols="1,1,3"]
+|===
+| `eval.c` (`struct choice`) | Compiled Z-machine (`CHOICE_*` record) | Meaning
+
+| (the array itself)
+| `CHOICE_CHOICE`
+| link to the previous, older choice point — the compiled form has to store
+  this explicitly, since it's a linked list in memory rather than a C array
+  with an implicit "previous element"
+
+| `nextcase`
+| `CHOICE_NEXTPC`
+| the routine to jump to on failure — the next clause, or the next branch
+  of a disjunction
+
+| `env`
+| `CHOICE_ENV`
+| environment-stack watermark to restore
+
+| `cont`
+| `CHOICE_CONT`
+| where to resume on success
+
+| `trail`
+| `CHOICE_TRAIL`
+| trail watermark: undo bindings back to here
+
+| `top`
+| `CHOICE_TOP`
+| heap watermark: reclaim memory back to here
+
+| `simple`
+| `CHOICE_SIMPLE`
+| whether the enclosing query context is a plain call or a {multi-query}
+
+| `arg[MAXPARAM + 1]`
+| (saved argument registers, following the fields above)
+| the call's argument values, as they were when this choice point was pushed
+|===
+
+Pushing a choice point (`I_PUSH_CHOICE` in the shared bytecode, described in
+xref:zcode.adoc[]) means, in the compiled story, allocating one such record
+in dynamic memory, filling in every one of those fields — including a copy
+of every current argument register — and linking it in by pointing
+`REG_CHOICE` at it, with the new record's `CHOICE_CHOICE` field preserving
+the address that was in `REG_CHOICE` a moment before. Backtracking into it
+later means the reverse: read `CHOICE_NEXTPC`, restore `REG_ENV`/the trail/
+the heap from the saved watermarks, restore the argument registers from the
+tail of the record, and jump. This is the same restore-four-numbers-and-jump
+operation described above for `eval.c`, just implemented directly in
+Z-machine memory instead of in a C struct.
+
+Failure works differently in the two implementations, though, for a very
+Z-machine-specific reason. In `eval.c`, a failing instruction can simply
+return a status code up the (C) call stack, because `eval_run()` is one big
+loop around a single dispatch `switch`, not a deep chain of nested C function
+calls. The compiled Z-machine story has no such luxury — a failure can occur
+many real Z-machine `call`s deep — so it uses the Z-machine's own
+`throw`/`catch` instructions to unwind however many stack frames are active
+in a single step, straight back to a small trampoline routine that reads
+`REG_CHOICE`'s `CHOICE_NEXTPC` and jumps there. `eval.c` doesn't need this
+trick, because its instruction dispatch loop is already flat.
+
+The upshot is that stepping through a Dialog predicate in `dgdebug` and
+disassembling the same predicate out of a compiled `z8` file will show you
+the same sequence of choice-point pushes, cuts, and unifications either way
+— just spelled differently, once as operations on `struct env`/`struct
+choice` and once as reads and writes into a hand-rolled slab of Z-machine
+dynamic memory.

--- a/manual/modules/internals/pages/rulesengine.adoc
+++ b/manual/modules/internals/pages/rulesengine.adoc
@@ -1,0 +1,171 @@
+= The rules engine and the debugger
+
+Once your program has been through the analysis passes described in
+xref:parsing.adoc[], it can be run directly, without ever being compiled to a
+Z-machine or Å-machine story. That's what `dgdebug` does. This page describes
+the engine that makes that possible (`src/eval.c`), and how `dgdebug`
+(`src/debugger.c`) is built on top of it.
+
+For how to actually *use* the interactive debugger — command-line options,
+`@`-commands, hot code reload from a user's point of view — see
+xref:ROOT:software.adoc#dgdebug[the debugger section of Part I]. This page
+covers how it's implemented.
+
+== Not a tree-walker
+
+It might seem natural for an interpreter to walk the syntax tree directly,
+recursively trying each goal in a clause body. Dialog's reference interpreter
+doesn't do that. Instead, `compile.c` first lowers every clause into a flat
+array of simple instructions — the same lowering step used to produce a
+compiled story, described in xref:zcode.adoc[] — and `eval.c` is a small
+virtual machine that executes that instruction array directly. The debugger
+and the Z-machine/Å-machine compiler are two different consumers of one
+shared intermediate representation, not two independent implementations of
+Dialog.
+
+This design is closely modelled on the WAM (the Warren Abstract Machine),
+the classic technique for compiling Prolog rather than interpreting it: terms
+live on a tagged heap, unification binds heap cells and records the bindings
+on a trail so they can be undone, and backtracking is driven by an explicit
+stack of choice points rather than by the language runtime's own call stack.
+
+== Terms: a tagged heap
+
+Every value in a running Dialog program — a number, an object, a dictionary
+word, a list cell, or an unbound variable — is a small tagged cell on a
+single, flat, growable heap. An unbound variable is represented as a cell
+that points to itself; binding it means overwriting that cell to point
+somewhere else. Following a chain of such references until you reach a cell
+that isn't a reference to something else (dereferencing) is the basic
+operation almost everything else builds on.
+
+*Unification* compares two values, following references on both sides first:
+binding an unbound variable to whatever the other side turns out to be,
+recursively matching the two parts of a pair against each other, and
+otherwise requiring an exact match. Every binding made this way is recorded
+on a *trail* — a simple list of "this cell used to be unbound" entries. To
+undo a set of bindings (because a goal failed and the engine needs to
+backtrack), the engine walks the trail back to a previously saved mark,
+resetting each recorded cell back to an unbound, self-referencing state. It
+also throws away anything allocated to the heap after that point. Nothing is
+copied; undoing a binding is as cheap as writing one word back.
+
+This trail-based undo is deliberately a different mechanism from the game-level
+`(undo)` command available to players. Trail-based undo only ever rewinds
+within a single query's backtracking search. `(undo)` (and the equivalent
+`(undo)`-adjacent commands in `dgdebug`, described below) instead take a full
+snapshot of the entire machine — every stack, the whole heap, all of it —
+and restore it wholesale later. The two mechanisms coexist because they solve
+different problems: one is about *exploring alternatives within a query*, the
+other is about *rewinding a whole turn of gameplay*.
+
+== Choice points, environments, and cut
+
+Two explicit stacks carry the engine's control state:
+
+* An *environment* holds the local variables belonging to one in-progress
+  clause activation, plus where to resume once that clause's body finishes.
+* A *choice point* records everything needed to retry a different
+  alternative later: which clause (or which branch of a disjunction) to try
+  next, together with saved marks for the heap, the trail, and the
+  environment stack, so that retrying can cleanly undo everything that
+  happened since.
+
+Compiling a predicate with several matching clauses means, in the simple
+case, pushing a choice point before trying the first clause (naming the next
+clause as what to retry on failure), and popping it once a later clause
+commits with nothing left to try. This is exactly the WAM's classic
+try/retry/trust pattern for clause selection, and the same instructions are
+reused for the language's other backtracking constructs — disjunction
+(`(or)`), and the "did the condition succeed" test in `(if)/(then)/(else)`.
+
+*Cut* — the underlying operation behind `(just)`, among other things —
+simply discards the innermost choice point outright, closing off any
+remaining alternatives for the goal it appears in. If-then constructs use a
+softer variant: save a mark before trying the condition, and if it succeeds,
+cut back to that mark afterwards, discarding only whatever choice points the
+*condition* created, while keeping the condition's variable bindings intact.
+
+[#simple-vs-multi]
+== Why a plain query only ever gives one answer
+
+A distinctive property of Dialog is that an ordinary query, written
+`(some predicate)`, can only ever succeed once, even if several of its clauses
+would have matched — you have to write the {multi-query} form,
+`*(some predicate)`, to backtrack into further alternatives. This isn't a
+special case bolted onto the engine; it falls directly out of how plain
+queries are compiled. Making a plain call records where the choice-point
+stack stood right before the call; once the call succeeds, everything pushed
+onto that stack while proving it is immediately cut away. A multi-query
+simply skips that automatic cut, leaving those choice points live so that a
+surrounding backtracking search can return to them later.
+
+== Aggregates: `(collect ... into ...)`
+
+Building up a list of every solution to a goal — what `(collect $X into $Xs)
+... $X ...` does — uses a third stack, separate from the heap and the trail.
+Entering a collect block marks the current position on this auxiliary stack;
+each time the inner goal succeeds (found by ordinary backtracking, exactly as
+above), the current value is pushed onto it; and once the inner goal is
+exhausted, everything pushed since the mark is folded back into a proper
+Dialog list and bound to the destination variable. The accumulating form of
+`(collect)` works the same way, except it keeps a running total instead of a
+growing list.
+
+== Object trees and dynamic predicates: a pluggable back end
+
+`eval.c` itself has no idea what a "room" or an "inventory" is, and no
+built-in notion of persistent game state. Everything to do with dynamic
+predicates — reading or setting a global flag, a global variable, an
+object's flag, or an object's variable, and walking the object containment
+tree — is reached through a small table of callback functions supplied by
+whoever is driving the engine. Iterating over "every child of this object" or
+"every object that currently has this flag" is compiled the same way ordinary
+clause backtracking is: each candidate becomes its own choice point, produced
+one at a time by asking the callback table for the next one.
+
+This indirection means the very same engine can run in two quite different
+modes. With a real callback table attached (backed by the live game state
+kept by `dgdebug`, described below), it plays the game. With *no* callback
+table attached at all, it's used by the compiler itself, to work out the
+default value of a dynamic predicate directly from its Dialog source rules
+before any game state exists — the value a fresh, unstarted game should see.
+A predicate compiled for that second purpose is checked to make sure it
+never actually tries to depend on live dynamic state, since none exists yet
+to answer it.
+
+== `dgdebug`: the engine, plus persistent state and developer tooling
+
+`src/debugger.c` is the `dgdebug` executable. Its central job is supplying the
+callback table described above: it owns the actual in-memory representation
+of every global flag and variable, every object's flags and variables, and
+the object containment tree, and implements each callback against that
+storage. On top of that live-state layer, it adds the developer-facing
+features described from a user's perspective in
+xref:ROOT:software.adoc#dgdebug[Part I]:
+
+* *Live source reload.* Before reading each new line of input, `dgdebug`
+  checks whether any source file has changed on disk, and if so, reruns the
+  entire frontend pipeline from xref:parsing.adoc[the previous page] on the
+  new source. Any dynamic predicate the player hasn't touched yet has its
+  default value recomputed from the new rules (using the compiler's
+  no-callbacks evaluation mode described above); anything already changed by
+  gameplay is left alone.
+* *Full-state undo.* Both the reference engine and the debugger's own game
+  state maintain a stack of complete snapshots, which is what backs the
+  player-visible `(undo)` command as well as `@again` in `dgdebug` (undo, then
+  replay the last line of input).
+* A handful of `@`-prefixed developer commands for inspecting that live
+  state directly — dumping every dynamic predicate's current value, or the
+  current shape of the object tree — and for recording and replaying a
+  whole session's worth of input.
+
+Structurally, the main loop in `dgdebug` never reaches into the engine's internal
+stacks directly. It only ever calls one of a handful of public entry points
+into `eval.c` (run the program, resume after supplying requested input, inject
+an ad hoc query typed at the prompt) and reacts to the status code each one
+returns — *waiting for input*, *suspended*, *hit a breakpoint*, and so on.
+Breakpoints and query tracing are themselves just two more kinds of compiled
+instruction, carrying the source file and line number they came from, so that
+messages printed while running under `dgdebug` can always point back at a
+specific place in your source code.

--- a/manual/modules/internals/pages/zcode.adoc
+++ b/manual/modules/internals/pages/zcode.adoc
@@ -24,6 +24,62 @@ of basic blocks per predicate. This is the exact same instruction stream that
 only ever produces it once, and it's `backend_z.c` (or the Å-machine backend,
 below) that decides how to turn it into a specific machine's native code.
 
+Concretely, one instruction is:
+
+[source,c]
+----
+struct cinstr {
+	uint8_t			op;		// I_* -- which operation
+	uint8_t			subop;		// a per-opcode mode flag
+	uint16_t		implicit;	// usually a branch target
+	value_t			oper[3];	// up to three tagged operands
+};
+----
+
+and one routine (a basic block) is:
+
+[source,c]
+----
+struct comp_routine {
+	struct cinstr		*instr;
+	uint16_t		ninstr;
+	uint16_t		clause_id;	// so the debugger can print variable names
+	uint16_t		diverted;
+	uint16_t		reftrack;	// used by a later reference-counting pass
+	uint16_t		n_edge_in;
+};
+----
+
+Every operand — and every value on `eval.c`'s heap, for that matter — is
+one `value_t`, a tag plus a 24-bit payload:
+
+[source,c]
+----
+typedef struct value {
+	int			tag:8;
+	int			value:24;
+} value_t;
+
+enum {
+	// run-time value tags
+	VAL_NUM, VAL_OBJ, VAL_DICT, VAL_DICTEXT, VAL_NIL, VAL_PAIR, VAL_REF,
+	// compile-time-only operand kinds, sharing the same tag space
+	OPER_ARG, OPER_TEMP, OPER_VAR, OPER_RLAB, OPER_GFLAG, OPER_GVAR,
+	OPER_OFLAG, OPER_OVAR, OPER_PRED,
+	// ...
+};
+----
+
+Reusing one tagged-value type for both "a value on the heap at run time" and
+"an operand of a compiled instruction" is deliberate: a `VAL_NUM`/`VAL_OBJ`/
+`VAL_PAIR`/`VAL_REF` operand is a constant baked directly into the
+instruction stream, while an `OPER_ARG`/`OPER_TEMP`/`OPER_VAR` operand tells
+a backend *where to find* a value at run time (an argument register, a
+scratch temporary, or a local variable slot) rather than what the value is.
+`compile.c` never needs to know or care which physical register or memory
+cell a backend will eventually use for `OPER_VAR` number 3, say — that
+decision is entirely `backend_z.c`'s (or `backend_aa.c`'s) to make.
+
 The instruction set is deliberately WAM-flavoured. Unification of a clause
 head against the values passed at a call site is compiled into explicit
 "construct" and "deconstruct" instructions on pairs and constants, rather
@@ -67,10 +123,20 @@ which range it falls in:
 * *Objects* are ordinary Z-machine objects, acted on with the Z-machine's own
   object-and-attribute instructions.
 * *Dictionary words* are ordinary Z-machine dictionary entries.
-* *Lists* are boxed references into a heap of pair cells, living in a region
-  of dynamic memory set aside for exactly this purpose.
-* *Unbound variables* are heap cells that (as in the reference engine) refer
-  to themselves until something binds them.
+* *Lists* are boxed references into a heap of pair cells: constructing a
+  pair writes two words (head, tail) into the next free heap slot and
+  returns a tagged reference to it, with the tag bits set by `OR`-ing in a
+  constant that's kept in its own dedicated global variable (so the constant
+  never has to be re-encoded inline every time it's needed).
+* *Unbound variables* are heap cells holding a plain `0`. Dereferencing a
+  reference means following it to its heap cell and, if that cell holds `0`,
+  stopping there — the cell is unbound. Otherwise the cell holds either
+  another reference (keep following it) or a tagged, final value (a pair, an
+  object, a number, ...), at which point dereferencing stops. This is
+  slightly different from the reference engine's encoding on the previous
+  page (there, an unbound cell refers to *itself* rather than holding `0`),
+  but it plays exactly the same role: an unmistakable, cheap-to-test sentinel
+  for "nothing bound here yet."
 
 === Where the choice-point machinery lives
 
@@ -101,7 +167,26 @@ that failed happened to be.
 
 A predicate you change with `(now)` is compiled to different physical storage
 depending on its arity and how it's used — the compiler picks whichever
-representation is cheapest for that particular predicate:
+representation is cheapest for that particular predicate. Every predicate
+compiled for the Z-machine carries one small record recording which choice
+was made for it:
+
+[source,c]
+----
+struct backend_pred {
+	int		global_label;		// address of this predicate's compiled routine
+	int		trace_output_label;
+	uint16_t	user_global;		// dedicated global variable, for a flag or a variable
+	uint16_t	user_flag_mask;		// which bit, if this is one flag among several sharing a global
+	int		object_flag;		// Z-machine attribute number, if it got one
+	int		propbase_label;		// base address of the per-object array, for a two-argument variable
+};
+----
+
+Which of `user_global`/`user_flag_mask`, `object_flag`, or `propbase_label`
+actually gets used (and whether `object_flag` refers to a real Z-machine
+attribute or an index into the runtime-managed fallback table mentioned
+below) depends on the storage strategy chosen for that particular predicate:
 
 * A flag-like predicate with no arguments becomes a single bit inside a
   shared Z-machine global variable.

--- a/manual/modules/internals/pages/zcode.adoc
+++ b/manual/modules/internals/pages/zcode.adoc
@@ -1,0 +1,150 @@
+= Compiling to Z-machine code
+
+This page describes what `dialogc` does differently from `dgdebug`: instead
+of executing the compiled intermediate representation directly (as described
+in xref:rulesengine.adoc[the previous page]), it translates that same
+representation into the native instruction set of a target virtual machine
+— by default, the Z-machine, the format used by Infocom's original games and
+supported by essentially every interactive fiction interpreter in existence.
+
+The relevant source is `src/compile.c`/`src/compile.h` (lowering the analyzed
+program into an intermediate bytecode) and `src/backend_z.c`/`src/backend_z.h`
+plus `src/zcode.h`/`src/runtime_z.c` (turning that bytecode into an actual
+Z-machine story file). The closing section covers `src/backend_aa.c`, a
+second, independent backend targeting a different machine entirely.
+
+== A shared, backend-neutral bytecode
+
+`compile.c` walks the fully analyzed program (see xref:parsing.adoc[]) and
+lowers every clause into a flat array of small, fixed-shape instructions:
+an operation code, a couple of mode bits, and up to three tagged operands.
+Runs of these instructions are grouped into routines, forming a small graph
+of basic blocks per predicate. This is the exact same instruction stream that
+`eval.c` executes directly, as described on the previous page — `compile.c`
+only ever produces it once, and it's `backend_z.c` (or the Å-machine backend,
+below) that decides how to turn it into a specific machine's native code.
+
+The instruction set is deliberately WAM-flavoured. Unification of a clause
+head against the values passed at a call site is compiled into explicit
+"construct" and "deconstruct" instructions on pairs and constants, rather
+than being handled by some generic runtime unify routine. Backtracking is
+compiled into a small, generic set of choice-point instructions: push a
+choice point naming an alternative to try later, pop one that's no longer
+needed, cut away the innermost one outright, or save and later restore back
+to a particular point — the same push/pop/cut/save/restore vocabulary
+described for the reference engine on the previous page. Because these are
+ordinary instructions in the same array as everything else, the compiler can
+run backend-independent optimization passes over them before any target-machine
+code exists at all — most importantly, recognizing when a choice point or an
+environment frame is never actually needed (because there's provably only one
+matching clause left, for instance) and removing it, which is what gives
+tail-recursive Dialog predicates roughly constant memory use.
+
+First-argument indexing — letting a call with a known, bound first argument
+jump straight to the one clause that could possibly match, instead of trying
+every clause in order — is likewise compiled directly into this bytecode, as
+a sorted chain of comparisons against the possible key values.
+
+== Turning bytecode into Z-machine code
+
+`backend_z.c` walks the routine graph produced above and, instruction by
+instruction, emits real Z-machine instructions. Simple instructions (moving a
+value, testing a tag) become one or two native instructions directly. More
+involved ones — pushing a choice point, looking up a dynamic predicate's
+current value — are compiled as a call into a fixed library of small support
+routines that's copied, unchanged, into every single story file the compiler
+produces. That shared support library plays a role very similar to what
+Inform calls a "veneer": a handful of hand-written low-level routines, in
+this case implementing the trickier parts of Prolog-style execution directly
+in Z-machine code, so that `backend_z.c` itself only has to emit a call to
+the right one.
+
+=== Where terms live at run time
+
+A Dialog value inside a compiled story is a single Z-machine word, tagged by
+which range it falls in:
+
+* *Objects* are ordinary Z-machine objects, acted on with the Z-machine's own
+  object-and-attribute instructions.
+* *Dictionary words* are ordinary Z-machine dictionary entries.
+* *Lists* are boxed references into a heap of pair cells, living in a region
+  of dynamic memory set aside for exactly this purpose.
+* *Unbound variables* are heap cells that (as in the reference engine) refer
+  to themselves until something binds them.
+
+=== Where the choice-point machinery lives
+
+Because the Z-machine has no native concept of backtracking, the entire
+mechanism described on the previous page — the heap, the trail, choice
+points, and environments — is built out of ordinary dynamic memory, addressed
+through a handful of global variables that the compiler reserves for its own
+use and never exposes to your Dialog code. One points at the current
+environment (an in-progress clause's local variables and where to resume);
+one points at the current choice point; one tracks how much of the trail is
+currently in use; one tracks the high-water mark of the heap. A choice point
+is a small fixed-layout record — a link back to the previous choice point,
+the address of the routine to retry, saved copies of the environment/trail/
+heap pointers at the time it was pushed, and the argument values live at that
+moment — so that choice points naturally form a linked list of "things to
+try if everything after this point fails."
+
+Failure itself uses the Z-machine's own `throw`/`catch` instructions. Rather
+than every routine explicitly checking "did that call fail?" and returning a
+failure code up through however many levels of nested calls happen to be
+active, a failing instruction simply throws, unwinding the entire Z-machine
+call stack in one step, straight back to a single trampoline routine that
+reads the current choice point's saved "retry here" address and jumps to it.
+This is what keeps failure cheap regardless of how deeply nested the call
+that failed happened to be.
+
+=== Dynamic predicates: several storage strategies, chosen per predicate
+
+A predicate you change with `(now)` is compiled to different physical storage
+depending on its arity and how it's used — the compiler picks whichever
+representation is cheapest for that particular predicate:
+
+* A flag-like predicate with no arguments becomes a single bit inside a
+  shared Z-machine global variable.
+* A single-argument "variable" predicate (something with one value at a
+  time, not tied to any object) becomes its own dedicated global variable.
+* A single-argument, per-object flag becomes a genuine Z-machine object
+  *attribute* whenever a free attribute slot is available (there's a limited
+  supply). Once those run out, additional per-object flags fall back to a
+  runtime-managed table instead; and per-object flags that are never changed
+  after startup can instead be baked down into a compact, static bit array,
+  avoiding attribute slots entirely.
+* A two-argument, per-object variable becomes an entry in a flat array
+  indexed directly by object number — not the Z-machine's native
+  variable-length property tables, which aren't a good fit for values that
+  change at run time.
+* The one built-in relation every Dialog program has — an object's parent
+  — is the sole exception: it's compiled straight onto the Z-machine's own
+  native object tree, rather than into any of the storage schemes above.
+  Dialog's object hierarchy *is* the Z-machine's object tree.
+
+Because a value written by `(now)` has to survive both ordinary backtracking
+*and* the player-visible `(undo)` command — both of which routinely roll the
+transient heap and trail back to an earlier state — setting such a value
+doesn't just write onto that transient heap. It's deep-copied into a
+separate, append-only "long-term" storage area first, and only a small,
+stable reference to that copy is stored in the flag/variable/array slot
+described above. Rolling back a choice point can safely erase anything on the
+transient heap without ever endangering a fact your game has already
+committed to.
+
+== A second backend, from the same bytecode
+
+`src/backend_aa.c` (together with `src/aavm.c`/`src/aavm.h`) is a completely
+independent code generator, targeting the Å-machine
+(pronounced "awe machine") instead of the Z-machine — see
+xref:ROOT:software.adoc#compiler[the compiler section of Part I] for what the
+Å-machine is for. Its instruction set is a near one-to-one mirror of the
+bytecode described above, and it implements the same choice-point/environment
+model against its own, simpler virtual machine. Concretely, this means the
+exact same compiled routine graph coming out of `compile.c` — unification,
+indexing, choice points, dynamic-predicate accesses, all of it — is fed to
+whichever backend the `-t` command-line option selects, without the frontend
+or the middle-end lowering step needing to know or care which one that will
+be. `src/backend.c`, the compiler's entry point, reflects this: after running
+the shared frontend and lowering pass, it makes exactly one choice of backend
+and hands the whole program off.


### PR DESCRIPTION
This documentation was generated by an LLM (Sonnet).  Do we have a policy for that?