### PR TITLE
Switch to new reverse-video CSS syntax

### DIFF
--- a/manual/modules/lang/pages/io.adoc
+++ b/manual/modules/lang/pages/io.adoc
@@ -94,8 +94,10 @@ Supported values are `normal`, `bold`, and `inherit`.
 font-family::
 The value is checked for the presence or absence of the keyword `monospace`, or for the exact text `inherit`.
 
-text-decoration::
-The value is checked for the presence or absence of the keyword `reverse`, or for the exact text `inherit`. A value containing `reverse` instructs the interpreter to reverse the foreground and background colors, whatever they might be; this is not standard CSS, but is more widely supported on retro hardware than setting the colors directly.
+-iftf-reverse-video::
+Supported values are `reverse`, `none`, and `inherit`. This is not standard CSS, and will not be recognized by the web interpreter; some platforms, like the Z-machine and the Apple II, have a special ability to swap their foreground and background colors, and this property was invented to represent that.
+
+CAUTION: Previous versions of Dialog used `text-decoration: reverse` for this purpose. This caused problems with other values of `text-decoration` on the web interpreter and has been removed.
 
 display::
 Supported values are `none` and `inherit`. Content marked with `display: none` is not displayed in any way, but _will_ appear in the xref:builtins.adoc#system[transcript]. If any important information is conveyed in a status area, this can be used to ensure it's also recorded in the transcript.
@@ -350,7 +352,7 @@ The Z-machine backend will reserve this many lines at the top of the screen.
 	}
 ----
 
-On the Z-machine, text inside the top status area is always rendered in a fixed-pitch font. Unless specified otherwise (with `text-decoration: none` in the style class), it will also be displayed in reverse video style.
+On the Z-machine, text inside the top status area is always rendered in a fixed-pitch font. Unless specified otherwise (with `-iftf-reverse-video: none` in the style class), it will also be displayed in reverse video style.
 When entering the status bar environment, Dialog fills the status area with space characters and positions the cursor in the top left corner.
 
 Inline style changes (bold, italic, reverse, fixed pitch, and roman) are ignored in the top status area, but spans are not.
@@ -469,9 +471,9 @@ All of them may be ignored by interpreters.
 [#dimensions]
 == Sizing
 
-For the most part, Dialog tries to present its output as a document: a series of words divided by spaces and breaks, partitioned off into divs and spans. The exact appearance of this document is then left to the interpreter to realize in whichever way is best for a given platform. Finer details, like the position of each character on the screen, are deliberately left unspecified—there might not even be a "screen" at all, if the game is being played through a screen reader or a messaging platform.
+For the most part, Dialog tries to present its output as a document: a series of words divided by spaces and breaks, partitioned off into divs and spans. The exact appearance of this document is then left to the interpreter to realize in whichever way is best for a given platform. Finer details, like the position of each character on the screen, are deliberately left unspecified—there might not even be a "screen" at all, if the game is being played through text-to-speech or a messaging platform.
 
-In some cases, though, the limitations of the Z-machine pose a problem for this model. On the Å-machine, for example, a status bar with `height: auto` will expand freely to fit its content. But on the Z-machine, the height of a status bar must always be specified before printing into it. In these cases, Dialog allows the author more fine-grained control; on more flexible backends, like the Å-machine, this additional detail is simply ignored.
+In some cases, though, the limitations of the Z-machine (and the 8-bit Å-machine interpreters) pose a problem for this model. In the Å-machine web interpreter, for example, a status bar with `height: auto` will expand freely to fit its content. But on the Z-machine, the height of a status bar must always be specified before printing into it. In these cases, Dialog allows the author more fine-grained control; on more flexible backends, this additional detail is simply ignored.
 
 [source,subs="quotes"]
 ----
@@ -495,7 +497,7 @@ However, note that not all interpreters can provide this information—on a scre
 reader or messaging platform, for example, there might not be any screen to
 measure! If this happens, the predicate will simply fail.
 
-On the Z-machine backend and the Commodore 64 Å-machine interpreter, these
+On the Z-machine backend and the 8-bit Å-machine interpreter, these
 predicates are most useful within the top status area, which always has fixed
 dimensions and a monospace font. If used anywhere else, they will attempt to 
 provide the width and height of the entire screen.

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,10 @@ Release notes:
 
 	1c/03, Lib 1.2.4:
 
-		Compiler: Patched over a bug with non-ASCII word separators.
+		Language: CSS text-decoration: reverse has been replaced with
+		-iftf-reverse-video: reverse for compatibility reasons.
+
+		Compiler: patched over a bug with non-ASCII word separators.
 		The problem isn't really fixed, but it will no longer corrupt
 		your game text.
 

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -2975,14 +2975,24 @@ int frontend(struct program *prg, int nfile, char **fname, dictmap_callback_t di
 					} else if(strcmp(param, "inherit")) { // Something that's not monospace was specified, and it was *not* inherit
 						bc->unstyle |= STYLE_FIXED;
 					}
-				} else if(1 == sscanf(str, "text-decoration : %s", param)) {
-					if(strstr(str, "reverse")) { // This is not a standard CSS property, but there is no standard CSS property for reverse video, and unrecognized property values are explicitly not an error in CSS
+				} else if(1 == sscanf(str, "-iftf-reverse-video : %s", param)) {
+					// The new, modern replacement for text-decoration: reverse
+					// See discussion at https://intfiction.org/t/should-we-standardize-a-pseudo-css-property-for-reverse-video/81692 for rationale
+					if(!strcmp(param, "reverse")) {
 						bc->style |= STYLE_REVERSE;
-					} else if(strcmp(param, "inherit")) { // As above, something that's not reverse was specified, and it's *not* inherit
+					} else if(!strcmp(param, "none")) {
 						bc->unstyle |= STYLE_REVERSE;
 					}
-					if(strstr(str, "debug")) { // It's sometimes useful to set the STYLE_DEBUG flag manually. This is deliberately not documented.
+				} else if(1 == sscanf(str, "-dialog-debug : %s", param)) {
+					// This is deliberately undocumented, but occasionally useful
+					if(!strcmp(param, "debug")) {
 						bc->style |= STYLE_DEBUG;
+					} else if(!strcmp(param, "none")) {
+						bc->unstyle |= STYLE_DEBUG;
+					}
+				} else if(1 == sscanf(str, "text-decoration : %s", param)) {
+					if(strstr(str, "reverse")) { // This used to be Dialog's way of specifying reverse-video style, but it caused problems: "text-decoration: underline reverse" would produce nothing in web browsers, rather than only an underline. So it's been replaced. (We use strstr and str here because sscanf breaks on the first whitespace, so param will have only the first word.)
+						report(LVL_WARN, 0, "'text-decoration: reverse' is no longer supported; use '-iftf-reverse-video: reverse' instead (in style class @%s)", bc->class->name);
 					}
 				} else if(1 == sscanf(str, "display : %s", param)) {
 					if(!strcmp(param, "none")) { // display:none indicates that a span/div should be sent to the transcript but not to the screen, like the quote boxes in Trinity


### PR DESCRIPTION
[Discussion.](https://intfiction.org/t/should-we-standardize-a-pseudo-css-property-for-reverse-video/81692?u=draconis)

This removes `text-decoration: reverse` in favor of `-iftf-reverse-video: reverse`. The former will now produce a warning and no effect.