### PR TITLE
Prevent hidden variables from interfering with closures

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -49,9 +49,12 @@ Release notes:
 		The problem isn't really fixed, but it will no longer corrupt
 		your game text.
 
-		Unit test runner: (game over) and (game over $) are
-		now overridden in unit.dg, to enable testing of win
-		conditions.
+		Compiler: re-fixed the obscure bug with divs and spans inside
+		closures, which was previously only fixed for the debugger, not
+		for the compiler. Oops!
+
+		Unit test runner: (game over) and (game over $) are now
+		overridden in unit.dg, to enable testing of win conditions.
 
 		Documentation: even more has been added to chapter 12.
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1366,6 +1366,9 @@ static struct astnode *parse_expr(int parsemode, struct lexer *lexer, struct are
 			for(i = 0; i < cl->nvar; i++) {
 				if(!strcmp(cl->varnames[i]->name, "_")) {
 					have_arg = 1;
+				} else if(cl->varnames[i]->name[0] == '*') {
+					// Internal variables (created via fresh_word) cannot be accessed outside the closure, so they should not be considered parameters
+					// We don't want them to interfere with the optimizer's analysis of whether parameters to ( invoke-closure $ $ $) are bound
 				} else {
 					sub = an->children[1];
 					an->children[1] = mkast(AN_PAIR, 2, cl->arena, orig_line);


### PR DESCRIPTION
Every div, span, and certain other constructions creates a hidden variable that's used for internal purposes.

These hidden variables should not be considered when determining if the inputs to a closure are bound or not.

For example, this source:

```
(style class @red) color: red;
(style class @green) color: green;

(interface (this should be bound $<This))
(this should be bound $This) $This

(program entry point)
	(query { (span @red) Red! })
	(query { (span @green) Green! })
	($B = 123)
	(query { (this should be bound $B) })
```

With the current compiler, it produces this:
```
Warning: closure-span.dg, line 11: Parameter #1 of (this should be bound $) can be (partially) unbound, which violates the interface declaration at closure-span.dg:4.
Warning: closure-span.dg, line 11: Parameter #1 of (this should be bound $) can be (partially) unbound, which violates the interface declaration at closure-span.dg:4.
```

Because the red and green spans introduce hidden variables that mean `( invoke-closure $ $ $)` does not have fully-bound parameters.

With this PR, those hidden variables are not included in the signature of `( invoke-closure $ $ $)` and thus will not be considered by the optimizer. Thus, no warnings.

This was previously reported as #291 and reported as fixed in #292 . However, that PR only fixed it for the debugger. This PR fixes it for the compiler as well.