### PR TITLE
Fix looking at incorrect header word for Standard revision

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -45,9 +45,12 @@ Release notes:
 
 	1c/03, Lib 1.2.4:
 
-		Compiler: Patched over a bug with non-ASCII word separators.
+		Compiler: patched over a bug with non-ASCII word separators.
 		The problem isn't really fixed, but it will no longer corrupt
 		your game text.
+
+		Backend: fixed bug with hex colors (#ff8800) on Z-machine
+		causing problems for older interpreters.
 
 		Unit test runner: (game over) and (game over $) are
 		now overridden in unit.dg, to enable testing of win

--- a/src/runtime_z.c
+++ b/src/runtime_z.c
@@ -716,9 +716,9 @@ struct rtroutine rtroutines[] = {
 			
 			// We also need to make sure the Standard revision is 1.1 or higher
 			// Otherwise, the Z_TRUECOLOR opcode won't exist! And might crash
-			{Z_LOADW, {SMALL(32), SMALL(0)}, REG_LOCAL+1},
+			{Z_LOADW, {SMALL(0x32), SMALL(0)}, REG_LOCAL+1},
 			// Upper byte = major version, lower byte = minor version
-			// So this needs to be at least 0x0101
+			// So this needs to be at least $0101
 			
 			{Z_JL, {VALUE(REG_FGCOLOR), SMALL(0)}, 0, 1}, // Is the foreground color negative? If so, we should do a "standard" setting instead of a "true" setting
 			{Z_JL, {VALUE(REG_LOCAL+1), LARGE(0x0101)}, 0, 2}, // And if this interpreter doesn't support the Z_TRUECOLOR opcode, we should skip this entirely


### PR DESCRIPTION
Before calling `@set_true_color`, Dialog checks the Standard revision number in the game header. But it was doing this wrong. Now it does it right.